### PR TITLE
Removing the master and slave language

### DIFF
--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/app/ext_runtimes/loader.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/app/ext_runtimes/loader.py
@@ -58,7 +58,7 @@ class InvalidRepositoryError(exceptions.Error):
   """Attempted to fetch or clone from a repository missing something basic.
 
   This gets raised if we try to fetch or clone from a repo that is either
-  missing a HEAD or missing both a "latest" tag and a master branch.
+  missing a HEAD or missing both a "latest" tag and a main branch.
   """
 
 
@@ -145,7 +145,7 @@ def _PullTags(local_repo, client_wrapper, target_dir):
 
   Returns:
     (str, dulwich.objects.Commit) The tag that was actually pulled (we try to
-    get "latest" but fall back to "master") and the commit object
+    get "latest" but fall back to "main") and the commit object
     associated with it.
 
   Raises:
@@ -162,7 +162,7 @@ def _PullTags(local_repo, client_wrapper, target_dir):
   # Try to get the "latest" tag (latest released version)
   revision = None
   tag = None
-  for tag in ('refs/tags/latest', 'refs/heads/master'):
+  for tag in ('refs/tags/latest', 'refs/heads/main'):
     try:
       log.debug('looking up ref %s', tag)
       revision = local_repo[tag]
@@ -171,7 +171,7 @@ def _PullTags(local_repo, client_wrapper, target_dir):
       log.warn('Unable to checkout branch %s', tag)
 
   else:
-    raise AssertionError('No "refs/heads/master" tag found in repository.')
+    raise AssertionError('No "refs/heads/main" tag found in repository.')
 
   return tag, revision
 
@@ -256,7 +256,7 @@ def InstallRuntimeDef(url, target_dir):
   directory.  At this time, the runtime definition url must be the URL of a
   git repository and we identify the tree to checkout based on 1) the presence
   of a "latest" tag ("refs/tags/latest") 2) if there is no "latest" tag, the
-  head of the "master" branch ("refs/heads/master").
+  head of the "main" branch ("refs/heads/main").
 
   Args:
     url: (str) A URL identifying a git repository.  The HTTP, TCP and local

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/container/api_adapter.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/container/api_adapter.py
@@ -386,13 +386,13 @@ class UpdateClusterOptions(object):
 
   def __init__(self,
                version=None,
-               update_master=None,
+               update_main=None,
                update_nodes=None,
                node_pool=None,
                update_cluster=None,
                monitoring_service=None):
     self.version = version
-    self.update_master = bool(update_master)
+    self.update_main = bool(update_main)
     self.update_nodes = bool(update_nodes)
     self.node_pool = node_pool
     self.update_cluster = bool(update_cluster)
@@ -419,7 +419,7 @@ class V1Adapter(APIAdapter):
     return cluster_ref.zone
 
   def Version(self, cluster):
-    return cluster.currentMasterVersion
+    return cluster.currentMainVersion
 
   def PrintClusters(self, clusters):
     list_printer.PrintResourceList(
@@ -451,7 +451,7 @@ class V1Adapter(APIAdapter):
         name=cluster_ref.clusterId,
         initialNodeCount=options.num_nodes,
         nodeConfig=node_config,
-        masterAuth=self.messages.MasterAuth(username=options.user,
+        mainAuth=self.messages.MainAuth(username=options.user,
                                             password=options.password))
     if options.cluster_version:
       cluster.initialClusterVersion = options.cluster_version
@@ -482,9 +482,9 @@ class V1Adapter(APIAdapter):
       update = self.messages.ClusterUpdate(
           desiredNodeVersion=options.version,
           desiredNodePoolId=options.node_pool)
-    elif options.update_master:
+    elif options.update_main:
       update = self.messages.ClusterUpdate(
-          desiredMasterVersion=options.version)
+          desiredMainVersion=options.version)
     elif options.update_cluster:
       update = self.messages.ClusterUpdate(
           desiredMonitoringService=options.monitoring_service)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/container/util.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/container/util.py
@@ -196,7 +196,7 @@ class ClusterConfig(object):
         'project_id': project_id,
         'server': 'https://' + cluster.endpoint,
     }
-    auth = cluster.masterAuth
+    auth = cluster.mainAuth
     if auth.clientCertificate and auth.clientKey and auth.clusterCaCertificate:
       kwargs['ca_data'] = auth.clusterCaCertificate
       kwargs['client_key_data'] = auth.clientKey

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/dataproc/compute_helpers.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/dataproc/compute_helpers.py
@@ -112,7 +112,7 @@ class ConfigurationHelper(scope_prompter.ScopePrompter):
       self,
       cluster_name,
       image,
-      master_machine_type,
+      main_machine_type,
       worker_machine_type,
       network,
       subnetwork):
@@ -122,9 +122,9 @@ class ConfigurationHelper(scope_prompter.ScopePrompter):
     region = compute_utils.ZoneNameToRegionName(zone)
     uris = {
         'image': self._GetResourceUri(image, 'images'),
-        'master_machine_type':
+        'main_machine_type':
             self._GetResourceUri(
-                master_machine_type, 'machineTypes', zone=zone),
+                main_machine_type, 'machineTypes', zone=zone),
         'worker_machine_type':
             self._GetResourceUri(
                 worker_machine_type, 'machineTypes', zone=zone),

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/dns/import_util.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/dns/import_util.py
@@ -59,7 +59,7 @@ def _SOATranslation(rdata, origin):
 
   Returns:
     str, The translation of the given SOA rdata which includes all the required
-    SOA fields. Note that the master NS name is left in a substitutable form
+    SOA fields. Note that the main NS name is left in a substitutable form
     because it is always provided by Cloud DNS.
   """
   return ' '.join(
@@ -214,7 +214,7 @@ def RecordSetsFromZoneFile(zone_file, domain):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     zone file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   zone_contents = zone.from_file(zone_file, domain, check_origin=False)
@@ -236,7 +236,7 @@ def RecordSetsFromYamlFile(yaml_file):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     yaml file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   record_sets = {}
@@ -256,7 +256,7 @@ def RecordSetsFromYamlFile(yaml_file):
     record_set.rrdatas = yaml_record_set['rrdatas']
 
     if rdata_type is rdatatype.SOA:
-      # Make master NS name substitutable.
+      # Make main NS name substitutable.
       record_set.rrdatas[0] = re.sub(r'\S+', '{0}', record_set.rrdatas[0],
                                      count=1)
 
@@ -284,14 +284,14 @@ def _RecordSetCopy(record_set):
 
 
 def _SOAReplacement(current_record, record_to_be_imported):
-  """Returns the replacement SOA record with restored master NS name.
+  """Returns the replacement SOA record with restored main NS name.
 
   Args:
     current_record: ResourceRecordSet, Current record-set.
     record_to_be_imported: ResourceRecordSet, Record-set to be imported.
 
   Returns:
-    ResourceRecordSet, the replacement SOA record with restored master NS name.
+    ResourceRecordSet, the replacement SOA record with restored main NS name.
   """
   replacement = _RecordSetCopy(record_to_be_imported)
   replacement.rrdatas[0] = replacement.rrdatas[0].format(

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/sql/instances.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/api_lib/sql/instances.py
@@ -167,11 +167,11 @@ class _BaseInstances(object):
     instance_resource = sql_messages.DatabaseInstance(
         region=region,
         databaseVersion=database_version,
-        masterInstanceName=getattr(args, 'master_instance_name', None),
+        mainInstanceName=getattr(args, 'main_instance_name', None),
         settings=settings)
 
-    if hasattr(args, 'master_instance_name'):
-      if args.master_instance_name:
+    if hasattr(args, 'main_instance_name'):
+      if args.main_instance_name:
         replication = 'ASYNCHRONOUS'
         activation_policy = 'ALWAYS'
       else:

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_client.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_client.py
@@ -33,33 +33,33 @@ class ContainerV1(base_api.BaseApiClient):
         credentials_args=credentials_args,
         default_global_params=default_global_params,
         additional_http_headers=additional_http_headers)
-    self.masterProjects_zones_signedUrls = self.MasterProjectsZonesSignedUrlsService(self)
-    self.masterProjects_zones_tokens = self.MasterProjectsZonesTokensService(self)
-    self.masterProjects_zones = self.MasterProjectsZonesService(self)
-    self.masterProjects = self.MasterProjectsService(self)
+    self.mainProjects_zones_signedUrls = self.MainProjectsZonesSignedUrlsService(self)
+    self.mainProjects_zones_tokens = self.MainProjectsZonesTokensService(self)
+    self.mainProjects_zones = self.MainProjectsZonesService(self)
+    self.mainProjects = self.MainProjectsService(self)
     self.projects_zones_clusters_nodePools = self.ProjectsZonesClustersNodePoolsService(self)
     self.projects_zones_clusters = self.ProjectsZonesClustersService(self)
     self.projects_zones_operations = self.ProjectsZonesOperationsService(self)
     self.projects_zones = self.ProjectsZonesService(self)
     self.projects = self.ProjectsService(self)
 
-  class MasterProjectsZonesSignedUrlsService(base_api.BaseApiService):
-    """Service class for the masterProjects_zones_signedUrls resource."""
+  class MainProjectsZonesSignedUrlsService(base_api.BaseApiService):
+    """Service class for the mainProjects_zones_signedUrls resource."""
 
-    _NAME = u'masterProjects_zones_signedUrls'
+    _NAME = u'mainProjects_zones_signedUrls'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsZonesSignedUrlsService, self).__init__(client)
+      super(ContainerV1.MainProjectsZonesSignedUrlsService, self).__init__(client)
       self._method_configs = {
           'Create': base_api.ApiMethodInfo(
               http_method=u'POST',
-              method_id=u'container.masterProjects.zones.signedUrls.create',
-              ordered_params=[u'masterProjectId', u'zone'],
-              path_params=[u'masterProjectId', u'zone'],
+              method_id=u'container.mainProjects.zones.signedUrls.create',
+              ordered_params=[u'mainProjectId', u'zone'],
+              path_params=[u'mainProjectId', u'zone'],
               query_params=[],
-              relative_path=u'v1/masterProjects/{masterProjectId}/zones/{zone}/signedUrls',
+              relative_path=u'v1/mainProjects/{mainProjectId}/zones/{zone}/signedUrls',
               request_field=u'createSignedUrlsRequest',
-              request_type_name=u'ContainerMasterProjectsZonesSignedUrlsCreateRequest',
+              request_type_name=u'ContainerMainProjectsZonesSignedUrlsCreateRequest',
               response_type_name=u'SignedUrls',
               supports_download=False,
           ),
@@ -70,11 +70,11 @@ class ContainerV1(base_api.BaseApiClient):
 
     def Create(self, request, global_params=None):
       """Creates signed URLs that allow for writing a file to a private GCS bucket.
-for storing backups of hosted master data. Signed URLs are explained here:
+for storing backups of hosted main data. Signed URLs are explained here:
 https://cloud.google.com/storage/docs/access-control#Signed-URLs
 
       Args:
-        request: (ContainerMasterProjectsZonesSignedUrlsCreateRequest) input message
+        request: (ContainerMainProjectsZonesSignedUrlsCreateRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
       Returns:
         (SignedUrls) The response message.
@@ -83,23 +83,23 @@ https://cloud.google.com/storage/docs/access-control#Signed-URLs
       return self._RunMethod(
           config, request, global_params=global_params)
 
-  class MasterProjectsZonesTokensService(base_api.BaseApiService):
-    """Service class for the masterProjects_zones_tokens resource."""
+  class MainProjectsZonesTokensService(base_api.BaseApiService):
+    """Service class for the mainProjects_zones_tokens resource."""
 
-    _NAME = u'masterProjects_zones_tokens'
+    _NAME = u'mainProjects_zones_tokens'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsZonesTokensService, self).__init__(client)
+      super(ContainerV1.MainProjectsZonesTokensService, self).__init__(client)
       self._method_configs = {
           'Create': base_api.ApiMethodInfo(
               http_method=u'POST',
-              method_id=u'container.masterProjects.zones.tokens.create',
-              ordered_params=[u'masterProjectId', u'zone'],
-              path_params=[u'masterProjectId', u'zone'],
+              method_id=u'container.mainProjects.zones.tokens.create',
+              ordered_params=[u'mainProjectId', u'zone'],
+              path_params=[u'mainProjectId', u'zone'],
               query_params=[],
-              relative_path=u'v1/masterProjects/{masterProjectId}/zones/{zone}/tokens',
+              relative_path=u'v1/mainProjects/{mainProjectId}/zones/{zone}/tokens',
               request_field=u'createTokenRequest',
-              request_type_name=u'ContainerMasterProjectsZonesTokensCreateRequest',
+              request_type_name=u'ContainerMainProjectsZonesTokensCreateRequest',
               response_type_name=u'Token',
               supports_download=False,
           ),
@@ -110,11 +110,11 @@ https://cloud.google.com/storage/docs/access-control#Signed-URLs
 
     def Create(self, request, global_params=None):
       """Creates a compute-read-write (https://www.googleapis.com/auth/compute).
-scoped OAuth2 access token for <project_number>, to allow a hosted master
+scoped OAuth2 access token for <project_number>, to allow a hosted main
 to make modifications to its user's project.
 
       Args:
-        request: (ContainerMasterProjectsZonesTokensCreateRequest) input message
+        request: (ContainerMainProjectsZonesTokensCreateRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
       Returns:
         (Token) The response message.
@@ -123,26 +123,26 @@ to make modifications to its user's project.
       return self._RunMethod(
           config, request, global_params=global_params)
 
-  class MasterProjectsZonesService(base_api.BaseApiService):
-    """Service class for the masterProjects_zones resource."""
+  class MainProjectsZonesService(base_api.BaseApiService):
+    """Service class for the mainProjects_zones resource."""
 
-    _NAME = u'masterProjects_zones'
+    _NAME = u'mainProjects_zones'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsZonesService, self).__init__(client)
+      super(ContainerV1.MainProjectsZonesService, self).__init__(client)
       self._method_configs = {
           }
 
       self._upload_configs = {
           }
 
-  class MasterProjectsService(base_api.BaseApiService):
-    """Service class for the masterProjects resource."""
+  class MainProjectsService(base_api.BaseApiService):
+    """Service class for the mainProjects resource."""
 
-    _NAME = u'masterProjects'
+    _NAME = u'mainProjects'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsService, self).__init__(client)
+      super(ContainerV1.MainProjectsService, self).__init__(client)
       self._method_configs = {
           }
 

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_messages.py
@@ -45,8 +45,8 @@ class Cluster(_messages.Message):
       automatically chosen or specify a `/14` block in `10.0.0.0/8`.
     createTime: [Output only] The time the cluster was created, in
       [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.
-    currentMasterVersion: [Output only] The current software version of the
-      master endpoint.
+    currentMainVersion: [Output only] The current software version of the
+      main endpoint.
     currentNodeCount: [Output only] The number of nodes currently in the
       cluster.
     currentNodeVersion: [Output only] The current version of the node software
@@ -54,11 +54,11 @@ class Cluster(_messages.Message):
       in the process of being upgraded, this reflects the minimum version of
       all nodes.
     description: An optional description of this cluster.
-    endpoint: [Output only] The IP address of this cluster's master endpoint.
+    endpoint: [Output only] The IP address of this cluster's main endpoint.
       The endpoint can be accessed from the internet at
-      `https://username:password@endpoint/`.  See the `masterAuth` property of
+      `https://username:password@endpoint/`.  See the `mainAuth` property of
       this resource for username and password information.
-    initialClusterVersion: [Output only] The software version of the master
+    initialClusterVersion: [Output only] The software version of the main
       endpoint and kubelets used in the cluster when it was first created. The
       version can be upgraded over time.
     initialNodeCount: The number of nodes to create in this cluster. You must
@@ -76,7 +76,7 @@ class Cluster(_messages.Message):
       Cloud Logging service. * `none` - no logs will be exported from the
       cluster. * if left as an empty string,`logging.googleapis.com` will be
       used.
-    masterAuth: The authentication information for accessing the master
+    mainAuth: The authentication information for accessing the main
       endpoint.
     monitoringService: The monitoring service the cluster should use to write
       metrics. Currently available options:  * `monitoring.googleapis.com` -
@@ -131,7 +131,7 @@ class Cluster(_messages.Message):
       RUNNING: The RUNNING state indicates the cluster has been created and is
         fully usable.
       RECONCILING: The RECONCILING state indicates that some work is actively
-        being done on the cluster, such as upgrading the master or node
+        being done on the cluster, such as upgrading the main or node
         software. Details can be found in the `statusMessage` field.
       STOPPING: The STOPPING state indicates the cluster is being deleted.
       ERROR: The ERROR state indicates the cluster may be unusable. Details
@@ -147,7 +147,7 @@ class Cluster(_messages.Message):
   addonsConfig = _messages.MessageField('AddonsConfig', 1)
   clusterIpv4Cidr = _messages.StringField(2)
   createTime = _messages.StringField(3)
-  currentMasterVersion = _messages.StringField(4)
+  currentMainVersion = _messages.StringField(4)
   currentNodeCount = _messages.IntegerField(5, variant=_messages.Variant.INT32)
   currentNodeVersion = _messages.StringField(6)
   description = _messages.StringField(7)
@@ -156,7 +156,7 @@ class Cluster(_messages.Message):
   initialNodeCount = _messages.IntegerField(10, variant=_messages.Variant.INT32)
   instanceGroupUrls = _messages.StringField(11, repeated=True)
   loggingService = _messages.StringField(12)
-  masterAuth = _messages.MessageField('MasterAuth', 13)
+  mainAuth = _messages.MessageField('MainAuth', 13)
   monitoringService = _messages.StringField(14)
   name = _messages.StringField(15)
   network = _messages.StringField(16)
@@ -179,11 +179,11 @@ class ClusterUpdate(_messages.Message):
   Fields:
     desiredAddonsConfig: Configurations for the various addons available to
       run in the cluster.
-    desiredMasterMachineType: The name of a Google Compute Engine [machine
+    desiredMainMachineType: The name of a Google Compute Engine [machine
       type](/compute/docs/machine-types) (e.g. `n1-standard-8`) to change the
-      master to.
-    desiredMasterVersion:  Whitelisted and internal users can change the
-      master to any version.  The Kubernetes version to change the master to.
+      main to.
+    desiredMainVersion:  Whitelisted and internal users can change the
+      main to any version.  The Kubernetes version to change the main to.
       The only valid value is the latest supported version. Use "-" to have
       the server automatically select the latest version.
     desiredMonitoringService: The monitoring service the cluster should use to
@@ -199,44 +199,44 @@ class ClusterUpdate(_messages.Message):
   """
 
   desiredAddonsConfig = _messages.MessageField('AddonsConfig', 1)
-  desiredMasterMachineType = _messages.StringField(2)
-  desiredMasterVersion = _messages.StringField(3)
+  desiredMainMachineType = _messages.StringField(2)
+  desiredMainVersion = _messages.StringField(3)
   desiredMonitoringService = _messages.StringField(4)
   desiredNodePoolId = _messages.StringField(5)
   desiredNodeVersion = _messages.StringField(6)
 
 
-class ContainerMasterProjectsZonesSignedUrlsCreateRequest(_messages.Message):
-  """A ContainerMasterProjectsZonesSignedUrlsCreateRequest object.
+class ContainerMainProjectsZonesSignedUrlsCreateRequest(_messages.Message):
+  """A ContainerMainProjectsZonesSignedUrlsCreateRequest object.
 
   Fields:
     createSignedUrlsRequest: A CreateSignedUrlsRequest resource to be passed
       as the request body.
-    masterProjectId: The hosted master project in which this master resides.
+    mainProjectId: The hosted main project in which this main resides.
       This can be either a [project ID or project
       number](https://support.google.com/cloud/answer/6158840).
-    zone: The zone of this master's cluster.
+    zone: The zone of this main's cluster.
   """
 
   createSignedUrlsRequest = _messages.MessageField('CreateSignedUrlsRequest', 1)
-  masterProjectId = _messages.StringField(2, required=True)
+  mainProjectId = _messages.StringField(2, required=True)
   zone = _messages.StringField(3, required=True)
 
 
-class ContainerMasterProjectsZonesTokensCreateRequest(_messages.Message):
-  """A ContainerMasterProjectsZonesTokensCreateRequest object.
+class ContainerMainProjectsZonesTokensCreateRequest(_messages.Message):
+  """A ContainerMainProjectsZonesTokensCreateRequest object.
 
   Fields:
     createTokenRequest: A CreateTokenRequest resource to be passed as the
       request body.
-    masterProjectId: The hosted master project in which this master resides.
+    mainProjectId: The hosted main project in which this main resides.
       This can be either a [project ID or project
       number](https://support.google.com/cloud/answer/6158840).
-    zone: The zone of this master's cluster.
+    zone: The zone of this main's cluster.
   """
 
   createTokenRequest = _messages.MessageField('CreateTokenRequest', 1)
-  masterProjectId = _messages.StringField(2, required=True)
+  mainProjectId = _messages.StringField(2, required=True)
   zone = _messages.StringField(3, required=True)
 
 
@@ -467,14 +467,14 @@ class CreateNodePoolRequest(_messages.Message):
 
 class CreateSignedUrlsRequest(_messages.Message):
   """A request for signed URLs that allow for writing a file to a private GCS
-  bucket for storing backups of hosted master data.
+  bucket for storing backups of hosted main data.
 
   Fields:
-    clusterId: The name of this master's cluster.
+    clusterId: The name of this main's cluster.
     filenames: The names of the files for which a signed URLs are being
       requested.
     projectNumber: The project number for which the signed URLs are being
-      requested.  This is the project in which this master's cluster resides.
+      requested.  This is the project in which this main's cluster resides.
       Note that this must be a project number, not a project ID.
   """
 
@@ -486,13 +486,13 @@ class CreateSignedUrlsRequest(_messages.Message):
 class CreateTokenRequest(_messages.Message):
   """A request for a compute-read-write
   (https://www.googleapis.com/auth/compute) scoped OAuth2 access token for
-  <project_number>, to allow hosted masters to make modifications to a user's
+  <project_number>, to allow hosted mains to make modifications to a user's
   project.
 
   Fields:
-    clusterId: The name of this master's cluster.
+    clusterId: The name of this main's cluster.
     projectNumber: The project number for which the access is being requested.
-      This is the project in which this master's cluster resides.  Note that
+      This is the project in which this main's cluster resides.  Note that
       this must be a project number, not a project ID.
   """
 
@@ -564,8 +564,8 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 2, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master endpoint.
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main endpoint.
   Authentication can be done using HTTP basic auth or using client
   certificates.
 
@@ -576,10 +576,10 @@ class MasterAuth(_messages.Message):
       authenticate to the cluster endpoint.
     clusterCaCertificate: [Output only] Base64-encoded public certificate that
       is the root of trust for the cluster.
-    password: The password to use for HTTP basic authentication to the master
-      endpoint. Because the master endpoint is open to the Internet, you
+    password: The password to use for HTTP basic authentication to the main
+      endpoint. Because the main endpoint is open to the Internet, you
       should create a strong password.
-    username: The username to use for HTTP basic authentication to the master
+    username: The username to use for HTTP basic authentication to the main
       endpoint.
   """
 
@@ -728,7 +728,7 @@ class NodeConfig(_messages.Message):
 class NodePool(_messages.Message):
   """NodePool contains the name and configuration for a cluster's node pool.
   Node pools are a set of nodes (i.e. VM's), with a common configuration and
-  specification, under the control of the cluster master. They may have a set
+  specification, under the control of the cluster main. They may have a set
   of Kubernetes labels applied to them, which may be used to reference them
   during pod scheduling. They may also be resized up or down, to accommodate
   the workload.
@@ -780,7 +780,7 @@ class Operation(_messages.Message):
       TYPE_UNSPECIFIED: Not set.
       CREATE_CLUSTER: Cluster create.
       DELETE_CLUSTER: Cluster delete.
-      UPGRADE_MASTER: A master upgrade.
+      UPGRADE_MASTER: A main upgrade.
       UPGRADE_NODES: A node upgrade.
       REPAIR_CLUSTER: Cluster repair.
       UPDATE_CLUSTER: Cluster update.
@@ -838,7 +838,7 @@ class ServerConfig(_messages.Message):
 
 class SignedUrls(_messages.Message):
   """Signed URLs that allow for writing a file to a private GCS bucket for
-  storing backups of hosted master data.
+  storing backups of hosted main data.
 
   Fields:
     signedUrls: The signed URLs for writing the request files, in the same
@@ -917,7 +917,7 @@ class StandardQueryParameters(_messages.Message):
 
 class Token(_messages.Message):
   """A compute-read-write (https://www.googleapis.com/auth/compute) scoped
-  OAuth2 access token, to allow hosted masters to make modifications to a
+  OAuth2 access token, to allow hosted mains to make modifications to a
   user's project.
 
   Fields:

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/dataproc/v1/dataproc_v1_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/dataproc/v1/dataproc_v1_messages.py
@@ -79,14 +79,14 @@ class ClusterConfig(_messages.Message):
     gceClusterConfig: [Required] The shared Google Compute Engine config
       settings for all instances in a cluster.
     initializationActions: [Optional] Commands to execute on each node after
-      config is completed. By default, executables are run on master and all
+      config is completed. By default, executables are run on main and all
       worker nodes. You can test a node's <code>role</code> metadata to run an
-      executable on a master or worker node, as shown below:
+      executable on a main or worker node, as shown below:
       ROLE=$(/usr/share/google/get_metadata_value attributes/role)     if [[
-      "${ROLE}" == 'Master' ]]; then       ... master specific actions ...
+      "${ROLE}" == 'Main' ]]; then       ... main specific actions ...
       else       ... worker specific actions ...     fi
-    masterConfig: [Optional] The Google Compute Engine config settings for the
-      master instance in a cluster.
+    mainConfig: [Optional] The Google Compute Engine config settings for the
+      main instance in a cluster.
     secondaryWorkerConfig: [Optional] The Google Compute Engine config
       settings for additional worker instances in a cluster.
     softwareConfig: [Optional] The config settings for software inside the
@@ -98,7 +98,7 @@ class ClusterConfig(_messages.Message):
   configBucket = _messages.StringField(1)
   gceClusterConfig = _messages.MessageField('GceClusterConfig', 2)
   initializationActions = _messages.MessageField('NodeInitializationAction', 3, repeated=True)
-  masterConfig = _messages.MessageField('InstanceGroupConfig', 4)
+  mainConfig = _messages.MessageField('InstanceGroupConfig', 4)
   secondaryWorkerConfig = _messages.MessageField('InstanceGroupConfig', 5)
   softwareConfig = _messages.MessageField('SoftwareConfig', 6)
   workerConfig = _messages.MessageField('InstanceGroupConfig', 7)
@@ -869,7 +869,7 @@ class HiveJob(_messages.Message):
 
 class InstanceGroupConfig(_messages.Message):
   """The config settings for Google Compute Engine resources in an instance
-  group, such as a master or worker group.
+  group, such as a main or worker group.
 
   Fields:
     diskConfig: Disk option config settings.
@@ -888,7 +888,7 @@ class InstanceGroupConfig(_messages.Message):
     managedGroupConfig: [Output-only] The config for Google Compute Engine
       Instance Group Manager that manages this group. This is only used for
       preemptible instance groups.
-    numInstances: The number of VM instances in the instance group. For master
+    numInstances: The number of VM instances in the instance group. For main
       instance groups, must be set to 1.
   """
 

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/genomics/v1/genomics_v1_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/genomics/v1/genomics_v1_messages.py
@@ -806,8 +806,8 @@ class ImportVariantsRequest(_messages.Message):
       FORMAT_UNSPECIFIED: <no description>
       FORMAT_VCF: VCF (Variant Call Format). The VCF files should be
         uncompressed. gVCF is also supported.
-      FORMAT_COMPLETE_GENOMICS: Complete Genomics masterVarBeta format. The
-        masterVarBeta files should be bzip2 compressed.
+      FORMAT_COMPLETE_GENOMICS: Complete Genomics mainVarBeta format. The
+        mainVarBeta files should be bzip2 compressed.
     """
     FORMAT_UNSPECIFIED = 0
     FORMAT_VCF = 1

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
@@ -150,7 +150,7 @@ class DatabaseInstance(_messages.Message):
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     project: The project ID of the project containing the Cloud SQL instance.
@@ -179,7 +179,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 6, repeated=True)
   ipv6Address = _messages.StringField(7)
   kind = _messages.StringField(8, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(9)
+  mainInstanceName = _messages.StringField(9)
   maxDiskSize = _messages.IntegerField(10)
   project = _messages.StringField(11)
   region = _messages.StringField(12)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
@@ -201,14 +201,14 @@ class DatabaseInstance(_messages.Message):
       property is applicable only to Second Generation instances.
     instanceType: The instance type. This can be one of the following.
       CLOUD_SQL_INSTANCE: A Cloud SQL instance that is not replicating from a
-      master. ON_PREMISES_INSTANCE: An instance running on the customer's
+      main. ON_PREMISES_INSTANCE: An instance running on the customer's
       premises. READ_REPLICA_INSTANCE: A Cloud SQL instance configured as a
       read-replica.
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance. This property is
       applicable only to First Generation instances.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     name: Name of the Cloud SQL instance. This does not include the project
@@ -222,7 +222,7 @@ class DatabaseInstance(_messages.Message):
       type (First Generation or Second Generation). The region can not be
       changed after instance creation.
     replicaConfiguration: Configuration specific to read-replicas replicating
-      from on-premises masters.
+      from on-premises mains.
     replicaNames: The replicas of the instance.
     selfLink: The URI of this resource.
     serverCaCert: SSL configuration.
@@ -247,7 +247,7 @@ class DatabaseInstance(_messages.Message):
 
     Fields:
       available: The availability status of the failover replica. A false
-        status indicates that the failover replica is out of sync. The master
+        status indicates that the failover replica is out of sync. The main
         can only failover to the falover replica when the status is true.
       name: The name of the failover replica.
     """
@@ -264,7 +264,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 7, repeated=True)
   ipv6Address = _messages.StringField(8)
   kind = _messages.StringField(9, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(10)
+  mainInstanceName = _messages.StringField(10)
   maxDiskSize = _messages.IntegerField(11)
   name = _messages.StringField(12)
   onPremisesConfiguration = _messages.MessageField('OnPremisesConfiguration', 13)
@@ -580,24 +580,24 @@ class MySqlReplicaConfiguration(_messages.Message):
 
   Fields:
     caCertificate: PEM representation of the trusted CA's x509 certificate.
-    clientCertificate: PEM representation of the slave's x509 certificate.
-    clientKey: PEM representation of the slave's private key. The
+    clientCertificate: PEM representation of the subordinate's x509 certificate.
+    clientKey: PEM representation of the subordinate's private key. The
       corresponsing public key is encoded in the client's certificate.
     connectRetryInterval: Seconds to wait between connect retries. MySQL's
       default is 60 seconds.
     dumpFilePath: Path to a SQL dump file in Google Cloud Storage from which
-      the slave instance is to be created. The URI is in the form
+      the subordinate instance is to be created. The URI is in the form
       gs://bucketName/fileName. Compressed gzip files (.gz) are also
       supported. Dumps should have the binlog co-ordinates from which
-      replication should begin. This can be accomplished by setting --master-
+      replication should begin. This can be accomplished by setting --main-
       data to 1 when using mysqldump.
     kind: This is always sql#mysqlReplicaConfiguration.
-    masterHeartbeatPeriod: Interval in milliseconds between replication
+    mainHeartbeatPeriod: Interval in milliseconds between replication
       heartbeats.
     password: The password for the replication connection.
     sslCipher: A list of permissible ciphers to use for SSL encryption.
     username: The username for the replication connection.
-    verifyServerCertificate: Whether or not to check the master's Common Name
+    verifyServerCertificate: Whether or not to check the main's Common Name
       value in the certificate that it sends during the SSL handshake.
   """
 
@@ -607,7 +607,7 @@ class MySqlReplicaConfiguration(_messages.Message):
   connectRetryInterval = _messages.IntegerField(4, variant=_messages.Variant.INT32)
   dumpFilePath = _messages.StringField(5)
   kind = _messages.StringField(6, default=u'sql#mysqlReplicaConfiguration')
-  masterHeartbeatPeriod = _messages.IntegerField(7)
+  mainHeartbeatPeriod = _messages.IntegerField(7)
   password = _messages.StringField(8)
   sslCipher = _messages.StringField(9)
   username = _messages.StringField(10)
@@ -721,22 +721,22 @@ class OperationsListResponse(_messages.Message):
 
 
 class ReplicaConfiguration(_messages.Message):
-  """Read-replica configuration for connecting to the master.
+  """Read-replica configuration for connecting to the main.
 
   Fields:
     failoverTarget: Specifies if the replica is the failover target. If the
       field is set to true the replica will be designated as a failover
-      replica. In case the master instance fails, the replica instance will be
-      promoted as the new master instance. Only one replica can be specified
+      replica. In case the main instance fails, the replica instance will be
+      promoted as the new main instance. Only one replica can be specified
       as failover target, and the replica has to be in different zone with the
-      master instance.
+      main instance.
     kind: This is always sql#replicaConfiguration.
     mysqlReplicaConfiguration: MySQL specific configuration when replicating
-      from a MySQL on-premises master. Replication configuration information
+      from a MySQL on-premises main. Replication configuration information
       such as the username, password, certificates, and keys are not stored in
       the instance metadata. The configuration information is used only to set
       up the replication connection and is stored by MySQL in a file named
-      master.info in the data directory.
+      main.info in the data directory.
   """
 
   failoverTarget = _messages.BooleanField(1)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apitools/base/py/batch.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/apitools/base/py/batch.py
@@ -174,7 +174,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/appengine/proto/protocoltype_pb.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/third_party/appengine/proto/protocoltype_pb.py
@@ -1053,8 +1053,8 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
   proto_name_ = ""
   has_proto2_file_descriptor_ = 0
   proto2_file_descriptor_ = ""
-  has_proto2_file_master_ = 0
-  proto2_file_master_ = ""
+  has_proto2_file_main_ = 0
+  proto2_file_main_ = ""
   has_proto2_name_ = 0
   proto2_name_ = ""
   has_proto2_extension_info_ = 0
@@ -1151,18 +1151,18 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
 
   def has_proto2_file_descriptor(self): return self.has_proto2_file_descriptor_
 
-  def proto2_file_master(self): return self.proto2_file_master_
+  def proto2_file_main(self): return self.proto2_file_main_
 
-  def set_proto2_file_master(self, x):
-    self.has_proto2_file_master_ = 1
-    self.proto2_file_master_ = x
+  def set_proto2_file_main(self, x):
+    self.has_proto2_file_main_ = 1
+    self.proto2_file_main_ = x
 
-  def clear_proto2_file_master(self):
-    if self.has_proto2_file_master_:
-      self.has_proto2_file_master_ = 0
-      self.proto2_file_master_ = ""
+  def clear_proto2_file_main(self):
+    if self.has_proto2_file_main_:
+      self.has_proto2_file_main_ = 0
+      self.proto2_file_main_ = ""
 
-  def has_proto2_file_master(self): return self.has_proto2_file_master_
+  def has_proto2_file_main(self): return self.has_proto2_file_main_
 
   def proto2_name(self): return self.proto2_name_
 
@@ -1212,7 +1212,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     for i in xrange(x.tag_size()): self.add_tag().CopyFrom(x.tag(i))
     for i in xrange(x.enumtype_size()): self.add_enumtype().CopyFrom(x.enumtype(i))
     if (x.has_proto2_file_descriptor()): self.set_proto2_file_descriptor(x.proto2_file_descriptor())
-    if (x.has_proto2_file_master()): self.set_proto2_file_master(x.proto2_file_master())
+    if (x.has_proto2_file_main()): self.set_proto2_file_main(x.proto2_file_main())
     if (x.has_proto2_name()): self.set_proto2_name(x.proto2_name())
     if (x.has_proto2_extension_info()): self.set_proto2_extension_info(x.proto2_extension_info())
     if (x.has_proto2_file_scope_info()): self.set_proto2_file_scope_info(x.proto2_file_scope_info())
@@ -1260,8 +1260,8 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
       if e1 != e2: return 0
     if self.has_proto2_file_descriptor_ != x.has_proto2_file_descriptor_: return 0
     if self.has_proto2_file_descriptor_ and self.proto2_file_descriptor_ != x.proto2_file_descriptor_: return 0
-    if self.has_proto2_file_master_ != x.has_proto2_file_master_: return 0
-    if self.has_proto2_file_master_ and self.proto2_file_master_ != x.proto2_file_master_: return 0
+    if self.has_proto2_file_main_ != x.has_proto2_file_main_: return 0
+    if self.has_proto2_file_main_ and self.proto2_file_main_ != x.proto2_file_main_: return 0
     if self.has_proto2_name_ != x.has_proto2_name_: return 0
     if self.has_proto2_name_ and self.proto2_name_ != x.proto2_name_: return 0
     if self.has_proto2_extension_info_ != x.has_proto2_extension_info_: return 0
@@ -1296,7 +1296,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     n += 2 * len(self.enumtype_)
     for i in xrange(len(self.enumtype_)): n += self.enumtype_[i].ByteSize()
     if (self.has_proto2_file_descriptor_): n += 2 + self.lengthString(len(self.proto2_file_descriptor_))
-    if (self.has_proto2_file_master_): n += 2 + self.lengthString(len(self.proto2_file_master_))
+    if (self.has_proto2_file_main_): n += 2 + self.lengthString(len(self.proto2_file_main_))
     if (self.has_proto2_name_): n += 2 + self.lengthString(len(self.proto2_name_))
     if (self.has_proto2_extension_info_): n += 2 + self.lengthString(len(self.proto2_extension_info_))
     if (self.has_proto2_file_scope_info_): n += 2 + self.lengthString(len(self.proto2_file_scope_info_))
@@ -1316,7 +1316,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     n += 2 * len(self.enumtype_)
     for i in xrange(len(self.enumtype_)): n += self.enumtype_[i].ByteSizePartial()
     if (self.has_proto2_file_descriptor_): n += 2 + self.lengthString(len(self.proto2_file_descriptor_))
-    if (self.has_proto2_file_master_): n += 2 + self.lengthString(len(self.proto2_file_master_))
+    if (self.has_proto2_file_main_): n += 2 + self.lengthString(len(self.proto2_file_main_))
     if (self.has_proto2_name_): n += 2 + self.lengthString(len(self.proto2_name_))
     if (self.has_proto2_extension_info_): n += 2 + self.lengthString(len(self.proto2_extension_info_))
     if (self.has_proto2_file_scope_info_): n += 2 + self.lengthString(len(self.proto2_file_scope_info_))
@@ -1329,7 +1329,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     self.clear_tag()
     self.clear_enumtype()
     self.clear_proto2_file_descriptor()
-    self.clear_proto2_file_master()
+    self.clear_proto2_file_main()
     self.clear_proto2_name()
     self.clear_proto2_extension_info()
     self.clear_proto2_file_scope_info()
@@ -1350,9 +1350,9 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     if (self.has_proto2_file_descriptor_):
       out.putVarInt32(186)
       out.putPrefixedString(self.proto2_file_descriptor_)
-    if (self.has_proto2_file_master_):
+    if (self.has_proto2_file_main_):
       out.putVarInt32(194)
-      out.putPrefixedString(self.proto2_file_master_)
+      out.putPrefixedString(self.proto2_file_main_)
     if (self.has_proto2_name_):
       out.putVarInt32(202)
       out.putPrefixedString(self.proto2_name_)
@@ -1384,9 +1384,9 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     if (self.has_proto2_file_descriptor_):
       out.putVarInt32(186)
       out.putPrefixedString(self.proto2_file_descriptor_)
-    if (self.has_proto2_file_master_):
+    if (self.has_proto2_file_main_):
       out.putVarInt32(194)
-      out.putPrefixedString(self.proto2_file_master_)
+      out.putPrefixedString(self.proto2_file_main_)
     if (self.has_proto2_name_):
       out.putVarInt32(202)
       out.putPrefixedString(self.proto2_name_)
@@ -1419,7 +1419,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
         self.set_proto2_file_descriptor(d.getPrefixedString())
         continue
       if tt == 194:
-        self.set_proto2_file_master(d.getPrefixedString())
+        self.set_proto2_file_main(d.getPrefixedString())
         continue
       if tt == 202:
         self.set_proto2_name(d.getPrefixedString())
@@ -1461,7 +1461,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
       res+=prefix+"}\n"
       cnt+=1
     if self.has_proto2_file_descriptor_: res+=prefix+("proto2_file_descriptor: %s\n" % self.DebugFormatString(self.proto2_file_descriptor_))
-    if self.has_proto2_file_master_: res+=prefix+("proto2_file_master: %s\n" % self.DebugFormatString(self.proto2_file_master_))
+    if self.has_proto2_file_main_: res+=prefix+("proto2_file_main: %s\n" % self.DebugFormatString(self.proto2_file_main_))
     if self.has_proto2_name_: res+=prefix+("proto2_name: %s\n" % self.DebugFormatString(self.proto2_name_))
     if self.has_proto2_extension_info_: res+=prefix+("proto2_extension_info: %s\n" % self.DebugFormatString(self.proto2_extension_info_))
     if self.has_proto2_file_scope_info_: res+=prefix+("proto2_file_scope_info: %s\n" % self.DebugFormatString(self.proto2_file_scope_info_))
@@ -1499,7 +1499,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
   kEnumTypeproto2_name = 31
   kEnumTypeallow_alias = 33
   kproto2_file_descriptor = 23
-  kproto2_file_master = 24
+  kproto2_file_main = 24
   kproto2_name = 25
   kproto2_extension_info = 29
   kproto2_file_scope_info = 30
@@ -1529,7 +1529,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     21: "name",
     22: "value",
     23: "proto2_file_descriptor",
-    24: "proto2_file_master",
+    24: "proto2_file_main",
     25: "proto2_name",
     26: "deprecated",
     27: "proto_name",

--- a/google-cloud-sdk/.install/.backup/lib/surface/container/clusters/get_credentials.py
+++ b/google-cloud-sdk/.install/.backup/lib/surface/container/clusters/get_credentials.py
@@ -58,7 +58,7 @@ class GetCredentials(base.Command):
     log.status.Print('Fetching cluster endpoint and auth data.')
     # Call DescribeCluster to get auth info and cache for next time
     cluster = adapter.GetCluster(cluster_ref)
-    if not cluster.masterAuth:
+    if not cluster.mainAuth:
       raise util.Error(
           'get-credentials requires edit permission on {0}'.format(
               cluster_ref.projectId))

--- a/google-cloud-sdk/.install/.backup/lib/surface/container/clusters/upgrade.py
+++ b/google-cloud-sdk/.install/.backup/lib/surface/container/clusters/upgrade.py
@@ -43,20 +43,20 @@ To upgrade nodes to the latest available version, run
 
 
 class VersionVerifier(object):
-  """Compares the cluster and master versions for upgrade availablity."""
+  """Compares the cluster and main versions for upgrade availablity."""
   UP_TO_DATE = 0
   UPGRADE_AVAILABLE = 1
   SUPPORT_ENDING = 2
   UNSUPPORTED = 3
 
-  def Compare(self, current_master_version, current_cluster_version):
-    """Compares the cluster and master versions and returns an enum."""
-    # TODO(user):update the if condition when we roll the master version
-    if current_master_version == current_cluster_version:
+  def Compare(self, current_main_version, current_cluster_version):
+    """Compares the cluster and main versions and returns an enum."""
+    # TODO(user):update the if condition when we roll the main version
+    if current_main_version == current_cluster_version:
       return self.UP_TO_DATE
-    master_version = SemVer(current_master_version)
+    main_version = SemVer(current_main_version)
     cluster_version = SemVer(current_cluster_version)
-    major, minor, _ = master_version.Distance(cluster_version)
+    major, minor, _ = main_version.Distance(cluster_version)
     if major != 0 or minor > 2:
       return self.UNSUPPORTED
     elif minor > 1:
@@ -85,19 +85,19 @@ class Upgrade(base.Command):
         '--cluster-version',
         help='The Kubernetes release version to which to upgrade the'
         ' cluster\'s nodes. Omit to upgrade the nodes to the version the'
-        ' cluster\'s Kubernetes master is running.')
+        ' cluster\'s Kubernetes main is running.')
     cv.detailed_help = """\
       The Kubernetes release version to which to upgrade the cluster's nodes.
-      Omit to upgrade the nodes to the version the cluster's Kubernetes master
+      Omit to upgrade the nodes to the version the cluster's Kubernetes main
       is running.
 
       If provided, the --cluster-version must be no greater than the cluster
-      master's minor version (x.*X*.x), and must be a latest patch version
+      main's minor version (x.*X*.x), and must be a latest patch version
       (x.x.*X*).
 
-      You can find the current master version by running
+      You can find the current main version by running
 
-        $ gcloud container clusters describe <cluster> | grep MasterVersion
+        $ gcloud container clusters describe <cluster> | grep MainVersion
 
       You can find the list of allowed node versions for upgrades by running
 
@@ -109,10 +109,10 @@ class Upgrade(base.Command):
         '--node-pool',
         help='The node pool to upgrade.')
     parser.add_argument(
-        '--master',
-        help='Upgrade the cluster\'s master to the latest version of Kubernetes'
+        '--main',
+        help='Upgrade the cluster\'s main to the latest version of Kubernetes'
         ' supported on Container Engine. Nodes cannot be upgraded at the same'
-        ' time as the master.',
+        ' time as the main.',
         action='store_true')
     parser.add_argument(
         '--wait',
@@ -140,8 +140,8 @@ class Upgrade(base.Command):
 
     options = api_adapter.UpdateClusterOptions(
         version=args.cluster_version,
-        update_master=args.master,
-        update_nodes=(not args.master),
+        update_main=args.main,
+        update_nodes=(not args.main),
         node_pool=args.node_pool)
 
     if options.version:
@@ -149,9 +149,9 @@ class Upgrade(base.Command):
     else:
       new_version = 'latest'
 
-    if args.master:
-      node_message = 'Master'
-      current_version = cluster.currentMasterVersion
+    if args.main:
+      node_message = 'Main'
+      current_version = cluster.currentMainVersion
     else:
       node_message = 'All {node_count} nodes'.format(
           node_count=cluster.currentNodeCount)
@@ -186,7 +186,7 @@ Upgrade.detailed_help = {
       Upgrades the Kubernetes version of an existing container cluster.
 
       This command upgrades the Kubernetes version of the *nodes* of a cluster.
-      The Kubernetes version of the cluster's *master* is periodically upgraded
+      The Kubernetes version of the cluster's *main* is periodically upgraded
       automatically as new releases are available.
 
       *By running this command, all of the cluster's nodes will be deleted and*
@@ -202,7 +202,7 @@ Upgrade.detailed_help = {
     """,
     'EXAMPLES': """\
       Upgrade the nodes of <cluster> to the Kubernetes version of the cluster's
-      master.
+      main.
 
         $ {command} <cluster>
 

--- a/google-cloud-sdk/.install/.backup/lib/surface/dataproc/clusters/create.py
+++ b/google-cloud-sdk/.install/.backup/lib/surface/dataproc/clusters/create.py
@@ -63,8 +63,8 @@ class Create(base.Command):
         type=int,
         help='The number of preemptible worker nodes in the cluster.')
     parser.add_argument(
-        '--master-machine-type',
-        help='The type of machine to use for the master. Defaults to '
+        '--main-machine-type',
+        help='The type of machine to use for the main. Defaults to '
         'server-specified.')
     parser.add_argument(
         '--worker-machine-type',
@@ -107,17 +107,17 @@ class Create(base.Command):
         type=int,
         help='The number of local SSDs to attach to each worker in a cluster.')
     parser.add_argument(
-        '--num-master-local-ssds',
+        '--num-main-local-ssds',
         type=int,
-        help='The number of local SSDs to attach to the master in a cluster.')
+        help='The number of local SSDs to attach to the main in a cluster.')
     parser.add_argument(
         '--worker-boot-disk-size-gb',
         type=int,
         help='The size in GB of the boot disk of each worker in a cluster.')
     parser.add_argument(
-        '--master-boot-disk-size-gb',
+        '--main-boot-disk-size-gb',
         type=int,
-        help='The size in GB of the boot disk of the master in a cluster.')
+        help='The size in GB of the boot disk of the main in a cluster.')
     parser.add_argument(
         '--initialization-actions',
         type=arg_parsers.ArgList(min_length=1),
@@ -215,7 +215,7 @@ Alias,URI
     compute_uris = config_helper.ResolveGceUris(
         args.name,
         args.image,
-        args.master_machine_type,
+        args.main_machine_type,
         args.worker_machine_type,
         args.network,
         args.subnet)
@@ -251,12 +251,12 @@ Alias,URI
     cluster_config = messages.ClusterConfig(
         configBucket=args.bucket,
         gceClusterConfig=gce_cluster_config,
-        masterConfig=messages.InstanceGroupConfig(
+        mainConfig=messages.InstanceGroupConfig(
             imageUri=compute_uris['image'],
-            machineTypeUri=compute_uris['master_machine_type'],
+            machineTypeUri=compute_uris['main_machine_type'],
             diskConfig=messages.DiskConfig(
-                bootDiskSizeGb=args.master_boot_disk_size_gb,
-                numLocalSsds=args.num_master_local_ssds,
+                bootDiskSizeGb=args.main_boot_disk_size_gb,
+                numLocalSsds=args.num_main_local_ssds,
             ),
         ),
         workerConfig=messages.InstanceGroupConfig(

--- a/google-cloud-sdk/.install/.backup/lib/surface/functions/deploy.py
+++ b/google-cloud-sdk/.install/.backup/lib/surface/functions/deploy.py
@@ -65,7 +65,7 @@ class Deploy(base.Command):
               'One of the parameters --source-revision, --source-branch, '
               'or --source-tag can be given to specify the version in the '
               'repository. If none of them are provided, the last revision '
-              'from the master branch is used. If this parameter is given, '
+              'from the main branch is used. If this parameter is given, '
               'the parameter --source is required and describes the path '
               'inside the repository.'))
     source_version_group = parser.add_mutually_exclusive_group()

--- a/google-cloud-sdk/.install/.backup/lib/surface/source/repos/clone.py
+++ b/google-cloud-sdk/.install/.backup/lib/surface/source/repos/clone.py
@@ -45,7 +45,7 @@ class Clone(base.Command):
             $ gcloud source repos clone default TARGET_DIR
             $ cd TARGET_DIR
             ... create/edit files and create one or more commits ...
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/google-cloud-sdk/.install/.backup/lib/surface/sql/instances/create.py
+++ b/google-cloud-sdk/.install/.backup/lib/surface/sql/instances/create.py
@@ -112,11 +112,11 @@ class _BaseCreate(object):
         'instance',
         help='Cloud SQL instance ID.')
     parser.add_argument(
-        '--master-instance-name',
+        '--main-instance-name',
         required=False,
-        help='Name of the instance which will act as master in the replication '
+        help='Name of the instance which will act as main in the replication '
         'setup. The newly created instance will be a read replica of the '
-        'specified master instance.')
+        'specified main instance.')
     parser.add_argument(
         '--on-premises-host-port',
         required=False,

--- a/google-cloud-sdk/.install/.backup/lib/third_party/dns/rdataset.py
+++ b/google-cloud-sdk/.install/.backup/lib/third_party/dns/rdataset.py
@@ -169,7 +169,7 @@ class Rdataset(dns.set.Set):
 
     def to_text(self, name=None, origin=None, relativize=True,
                 override_rdclass=None, **kw):
-        """Convert the rdataset into DNS master file format.
+        """Convert the rdataset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/google-cloud-sdk/.install/.backup/lib/third_party/dns/rdtypes/ANY/SOA.py
+++ b/google-cloud-sdk/.install/.backup/lib/third_party/dns/rdtypes/ANY/SOA.py
@@ -22,7 +22,7 @@ import dns.name
 class SOA(dns.rdata.Rdata):
     """SOA record
 
-    @ivar mname: the SOA MNAME (master name) field
+    @ivar mname: the SOA MNAME (main name) field
     @type mname: dns.name.Name object
     @ivar rname: the SOA RNAME (responsible name) field
     @type rname: dns.name.Name object

--- a/google-cloud-sdk/.install/.backup/lib/third_party/dns/rrset.py
+++ b/google-cloud-sdk/.install/.backup/lib/third_party/dns/rrset.py
@@ -84,7 +84,7 @@ class RRset(dns.rdataset.Rdataset):
         return True
 
     def to_text(self, origin=None, relativize=True, **kw):
-        """Convert the RRset into DNS master file format.
+        """Convert the RRset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/google-cloud-sdk/.install/.backup/lib/third_party/dns/tokenizer.py
+++ b/google-cloud-sdk/.install/.backup/lib/third_party/dns/tokenizer.py
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Tokenize DNS master file format"""
+"""Tokenize DNS main file format"""
 
 import cStringIO
 import sys
@@ -47,7 +47,7 @@ class UngetBufferFull(dns.exception.DNSException):
     pass
 
 class Token(object):
-    """A DNS master file format token.
+    """A DNS main file format token.
 
     @ivar ttype: The token type
     @type ttype: int
@@ -156,7 +156,7 @@ class Token(object):
             raise IndexError
 
 class Tokenizer(object):
-    """A DNS master file format tokenizer.
+    """A DNS main file format tokenizer.
 
     A token is a (type, value) tuple, where I{type} is an int, and
     I{value} is a string.  The valid types are EOF, EOL, WHITESPACE,

--- a/google-cloud-sdk/.install/.backup/lib/third_party/dns/zone.py
+++ b/google-cloud-sdk/.install/.backup/lib/third_party/dns/zone.py
@@ -520,8 +520,8 @@ class Zone(object):
             raise NoNS
 
 
-class _MasterReader(object):
-    """Read a DNS master file
+class _MainReader(object):
+    """Read a DNS main file
 
     @ivar tok: The tokenizer
     @type tok: dns.tokenizer.Tokenizer object
@@ -569,7 +569,7 @@ class _MasterReader(object):
                 break
 
     def _rr_line(self):
-        """Process one line from a DNS master file."""
+        """Process one line from a DNS main file."""
         # Name
         if self.current_origin is None:
             raise UnknownOrigin
@@ -642,7 +642,7 @@ class _MasterReader(object):
         rds.add(rd, ttl)
 
     def read(self):
-        """Read a DNS master file and build a zone object.
+        """Read a DNS main file and build a zone object.
 
         @raises dns.zone.NoSOA: No SOA RR was found at the zone origin
         @raises dns.zone.NoNS: No NS RRset was found at the zone origin
@@ -704,7 +704,7 @@ class _MasterReader(object):
                                                            filename)
                         self.current_origin = new_origin
                     else:
-                        raise dns.exception.SyntaxError("Unknown master file directive '" + u + "'")
+                        raise dns.exception.SyntaxError("Unknown main file directive '" + u + "'")
                     continue
                 self.tok.unget(token)
                 self._rr_line()
@@ -721,12 +721,12 @@ class _MasterReader(object):
 def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=False, check_origin=True):
-    """Build a zone object from a master file format string.
+    """Build a zone object from a main file format string.
 
-    @param text: the master file format input
+    @param text: the main file format input
     @type text: string.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.
@@ -755,7 +755,7 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
     if filename is None:
         filename = '<string>'
     tok = dns.tokenizer.Tokenizer(text, filename)
-    reader = _MasterReader(tok, origin, rdclass, relativize, zone_factory,
+    reader = _MainReader(tok, origin, rdclass, relativize, zone_factory,
                            allow_include=allow_include,
                            check_origin=check_origin)
     reader.read()
@@ -764,12 +764,12 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
 def from_file(f, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=True, check_origin=True):
-    """Read a master file and build a zone object.
+    """Read a main file and build a zone object.
 
     @param f: file or string.  If I{f} is a string, it is treated
     as the name of a file to open.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.

--- a/google-cloud-sdk/.install/.backup/lib/third_party/dulwich/repo.py
+++ b/google-cloud-sdk/.install/.backup/lib/third_party/dulwich/repo.py
@@ -790,8 +790,8 @@ class Repo(BaseRepo):
             b'refs/tags', self.refs.as_dict(b'refs/tags'))
         try:
             target.refs.add_if_new(
-                b'refs/heads/master',
-                self.refs[b'refs/heads/master'])
+                b'refs/heads/main',
+                self.refs[b'refs/heads/main'])
         except KeyError:
             pass
 
@@ -876,7 +876,7 @@ class Repo(BaseRepo):
             os.mkdir(os.path.join(path, *d))
         DiskObjectStore.init(os.path.join(path, OBJECTDIR))
         ret = cls(path)
-        ret.refs.set_symbolic_ref(b'HEAD', b"refs/heads/master")
+        ret.refs.set_symbolic_ref(b'HEAD', b"refs/heads/main")
         ret._init_files(bare)
         return ret
 

--- a/google-cloud-sdk/.install/.backup/lib/third_party/jinja2/pkg_resources.py
+++ b/google-cloud-sdk/.install/.backup/lib/third_party/jinja2/pkg_resources.py
@@ -2693,7 +2693,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 
 try:

--- a/google-cloud-sdk/lib/googlecloudsdk/api_lib/app/ext_runtimes/loader.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/api_lib/app/ext_runtimes/loader.py
@@ -58,7 +58,7 @@ class InvalidRepositoryError(exceptions.Error):
   """Attempted to fetch or clone from a repository missing something basic.
 
   This gets raised if we try to fetch or clone from a repo that is either
-  missing a HEAD or missing both a "latest" tag and a master branch.
+  missing a HEAD or missing both a "latest" tag and a main branch.
   """
 
 
@@ -145,7 +145,7 @@ def _PullTags(local_repo, client_wrapper, target_dir):
 
   Returns:
     (str, dulwich.objects.Commit) The tag that was actually pulled (we try to
-    get "latest" but fall back to "master") and the commit object
+    get "latest" but fall back to "main") and the commit object
     associated with it.
 
   Raises:
@@ -162,7 +162,7 @@ def _PullTags(local_repo, client_wrapper, target_dir):
   # Try to get the "latest" tag (latest released version)
   revision = None
   tag = None
-  for tag in ('refs/tags/latest', 'refs/heads/master'):
+  for tag in ('refs/tags/latest', 'refs/heads/main'):
     try:
       log.debug('looking up ref %s', tag)
       revision = local_repo[tag]
@@ -171,7 +171,7 @@ def _PullTags(local_repo, client_wrapper, target_dir):
       log.warn('Unable to checkout branch %s', tag)
 
   else:
-    raise AssertionError('No "refs/heads/master" tag found in repository.')
+    raise AssertionError('No "refs/heads/main" tag found in repository.')
 
   return tag, revision
 
@@ -256,7 +256,7 @@ def InstallRuntimeDef(url, target_dir):
   directory.  At this time, the runtime definition url must be the URL of a
   git repository and we identify the tree to checkout based on 1) the presence
   of a "latest" tag ("refs/tags/latest") 2) if there is no "latest" tag, the
-  head of the "master" branch ("refs/heads/master").
+  head of the "main" branch ("refs/heads/main").
 
   Args:
     url: (str) A URL identifying a git repository.  The HTTP, TCP and local

--- a/google-cloud-sdk/lib/googlecloudsdk/api_lib/container/api_adapter.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/api_lib/container/api_adapter.py
@@ -386,13 +386,13 @@ class UpdateClusterOptions(object):
 
   def __init__(self,
                version=None,
-               update_master=None,
+               update_main=None,
                update_nodes=None,
                node_pool=None,
                update_cluster=None,
                monitoring_service=None):
     self.version = version
-    self.update_master = bool(update_master)
+    self.update_main = bool(update_main)
     self.update_nodes = bool(update_nodes)
     self.node_pool = node_pool
     self.update_cluster = bool(update_cluster)
@@ -419,7 +419,7 @@ class V1Adapter(APIAdapter):
     return cluster_ref.zone
 
   def Version(self, cluster):
-    return cluster.currentMasterVersion
+    return cluster.currentMainVersion
 
   def PrintClusters(self, clusters):
     list_printer.PrintResourceList(
@@ -451,7 +451,7 @@ class V1Adapter(APIAdapter):
         name=cluster_ref.clusterId,
         initialNodeCount=options.num_nodes,
         nodeConfig=node_config,
-        masterAuth=self.messages.MasterAuth(username=options.user,
+        mainAuth=self.messages.MainAuth(username=options.user,
                                             password=options.password))
     if options.cluster_version:
       cluster.initialClusterVersion = options.cluster_version
@@ -482,9 +482,9 @@ class V1Adapter(APIAdapter):
       update = self.messages.ClusterUpdate(
           desiredNodeVersion=options.version,
           desiredNodePoolId=options.node_pool)
-    elif options.update_master:
+    elif options.update_main:
       update = self.messages.ClusterUpdate(
-          desiredMasterVersion=options.version)
+          desiredMainVersion=options.version)
     elif options.update_cluster:
       update = self.messages.ClusterUpdate(
           desiredMonitoringService=options.monitoring_service)

--- a/google-cloud-sdk/lib/googlecloudsdk/api_lib/container/util.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/api_lib/container/util.py
@@ -196,7 +196,7 @@ class ClusterConfig(object):
         'project_id': project_id,
         'server': 'https://' + cluster.endpoint,
     }
-    auth = cluster.masterAuth
+    auth = cluster.mainAuth
     if auth.clientCertificate and auth.clientKey and auth.clusterCaCertificate:
       kwargs['ca_data'] = auth.clusterCaCertificate
       kwargs['client_key_data'] = auth.clientKey

--- a/google-cloud-sdk/lib/googlecloudsdk/api_lib/dataproc/compute_helpers.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/api_lib/dataproc/compute_helpers.py
@@ -112,7 +112,7 @@ class ConfigurationHelper(scope_prompter.ScopePrompter):
       self,
       cluster_name,
       image,
-      master_machine_type,
+      main_machine_type,
       worker_machine_type,
       network,
       subnetwork):
@@ -122,9 +122,9 @@ class ConfigurationHelper(scope_prompter.ScopePrompter):
     region = compute_utils.ZoneNameToRegionName(zone)
     uris = {
         'image': self._GetResourceUri(image, 'images'),
-        'master_machine_type':
+        'main_machine_type':
             self._GetResourceUri(
-                master_machine_type, 'machineTypes', zone=zone),
+                main_machine_type, 'machineTypes', zone=zone),
         'worker_machine_type':
             self._GetResourceUri(
                 worker_machine_type, 'machineTypes', zone=zone),

--- a/google-cloud-sdk/lib/googlecloudsdk/api_lib/dns/import_util.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/api_lib/dns/import_util.py
@@ -59,7 +59,7 @@ def _SOATranslation(rdata, origin):
 
   Returns:
     str, The translation of the given SOA rdata which includes all the required
-    SOA fields. Note that the master NS name is left in a substitutable form
+    SOA fields. Note that the main NS name is left in a substitutable form
     because it is always provided by Cloud DNS.
   """
   return ' '.join(
@@ -214,7 +214,7 @@ def RecordSetsFromZoneFile(zone_file, domain):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     zone file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   zone_contents = zone.from_file(zone_file, domain, check_origin=False)
@@ -236,7 +236,7 @@ def RecordSetsFromYamlFile(yaml_file):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     yaml file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   record_sets = {}
@@ -256,7 +256,7 @@ def RecordSetsFromYamlFile(yaml_file):
     record_set.rrdatas = yaml_record_set['rrdatas']
 
     if rdata_type is rdatatype.SOA:
-      # Make master NS name substitutable.
+      # Make main NS name substitutable.
       record_set.rrdatas[0] = re.sub(r'\S+', '{0}', record_set.rrdatas[0],
                                      count=1)
 
@@ -284,14 +284,14 @@ def _RecordSetCopy(record_set):
 
 
 def _SOAReplacement(current_record, record_to_be_imported):
-  """Returns the replacement SOA record with restored master NS name.
+  """Returns the replacement SOA record with restored main NS name.
 
   Args:
     current_record: ResourceRecordSet, Current record-set.
     record_to_be_imported: ResourceRecordSet, Record-set to be imported.
 
   Returns:
-    ResourceRecordSet, the replacement SOA record with restored master NS name.
+    ResourceRecordSet, the replacement SOA record with restored main NS name.
   """
   replacement = _RecordSetCopy(record_to_be_imported)
   replacement.rrdatas[0] = replacement.rrdatas[0].format(

--- a/google-cloud-sdk/lib/googlecloudsdk/api_lib/sql/instances.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/api_lib/sql/instances.py
@@ -167,11 +167,11 @@ class _BaseInstances(object):
     instance_resource = sql_messages.DatabaseInstance(
         region=region,
         databaseVersion=database_version,
-        masterInstanceName=getattr(args, 'master_instance_name', None),
+        mainInstanceName=getattr(args, 'main_instance_name', None),
         settings=settings)
 
-    if hasattr(args, 'master_instance_name'):
-      if args.master_instance_name:
+    if hasattr(args, 'main_instance_name'):
+      if args.main_instance_name:
         replication = 'ASYNCHRONOUS'
         activation_policy = 'ALWAYS'
       else:

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_client.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_client.py
@@ -33,33 +33,33 @@ class ContainerV1(base_api.BaseApiClient):
         credentials_args=credentials_args,
         default_global_params=default_global_params,
         additional_http_headers=additional_http_headers)
-    self.masterProjects_zones_signedUrls = self.MasterProjectsZonesSignedUrlsService(self)
-    self.masterProjects_zones_tokens = self.MasterProjectsZonesTokensService(self)
-    self.masterProjects_zones = self.MasterProjectsZonesService(self)
-    self.masterProjects = self.MasterProjectsService(self)
+    self.mainProjects_zones_signedUrls = self.MainProjectsZonesSignedUrlsService(self)
+    self.mainProjects_zones_tokens = self.MainProjectsZonesTokensService(self)
+    self.mainProjects_zones = self.MainProjectsZonesService(self)
+    self.mainProjects = self.MainProjectsService(self)
     self.projects_zones_clusters_nodePools = self.ProjectsZonesClustersNodePoolsService(self)
     self.projects_zones_clusters = self.ProjectsZonesClustersService(self)
     self.projects_zones_operations = self.ProjectsZonesOperationsService(self)
     self.projects_zones = self.ProjectsZonesService(self)
     self.projects = self.ProjectsService(self)
 
-  class MasterProjectsZonesSignedUrlsService(base_api.BaseApiService):
-    """Service class for the masterProjects_zones_signedUrls resource."""
+  class MainProjectsZonesSignedUrlsService(base_api.BaseApiService):
+    """Service class for the mainProjects_zones_signedUrls resource."""
 
-    _NAME = u'masterProjects_zones_signedUrls'
+    _NAME = u'mainProjects_zones_signedUrls'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsZonesSignedUrlsService, self).__init__(client)
+      super(ContainerV1.MainProjectsZonesSignedUrlsService, self).__init__(client)
       self._method_configs = {
           'Create': base_api.ApiMethodInfo(
               http_method=u'POST',
-              method_id=u'container.masterProjects.zones.signedUrls.create',
-              ordered_params=[u'masterProjectId', u'zone'],
-              path_params=[u'masterProjectId', u'zone'],
+              method_id=u'container.mainProjects.zones.signedUrls.create',
+              ordered_params=[u'mainProjectId', u'zone'],
+              path_params=[u'mainProjectId', u'zone'],
               query_params=[],
-              relative_path=u'v1/masterProjects/{masterProjectId}/zones/{zone}/signedUrls',
+              relative_path=u'v1/mainProjects/{mainProjectId}/zones/{zone}/signedUrls',
               request_field=u'createSignedUrlsRequest',
-              request_type_name=u'ContainerMasterProjectsZonesSignedUrlsCreateRequest',
+              request_type_name=u'ContainerMainProjectsZonesSignedUrlsCreateRequest',
               response_type_name=u'SignedUrls',
               supports_download=False,
           ),
@@ -70,11 +70,11 @@ class ContainerV1(base_api.BaseApiClient):
 
     def Create(self, request, global_params=None):
       """Creates signed URLs that allow for writing a file to a private GCS bucket.
-for storing backups of hosted master data. Signed URLs are explained here:
+for storing backups of hosted main data. Signed URLs are explained here:
 https://cloud.google.com/storage/docs/access-control#Signed-URLs
 
       Args:
-        request: (ContainerMasterProjectsZonesSignedUrlsCreateRequest) input message
+        request: (ContainerMainProjectsZonesSignedUrlsCreateRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
       Returns:
         (SignedUrls) The response message.
@@ -83,23 +83,23 @@ https://cloud.google.com/storage/docs/access-control#Signed-URLs
       return self._RunMethod(
           config, request, global_params=global_params)
 
-  class MasterProjectsZonesTokensService(base_api.BaseApiService):
-    """Service class for the masterProjects_zones_tokens resource."""
+  class MainProjectsZonesTokensService(base_api.BaseApiService):
+    """Service class for the mainProjects_zones_tokens resource."""
 
-    _NAME = u'masterProjects_zones_tokens'
+    _NAME = u'mainProjects_zones_tokens'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsZonesTokensService, self).__init__(client)
+      super(ContainerV1.MainProjectsZonesTokensService, self).__init__(client)
       self._method_configs = {
           'Create': base_api.ApiMethodInfo(
               http_method=u'POST',
-              method_id=u'container.masterProjects.zones.tokens.create',
-              ordered_params=[u'masterProjectId', u'zone'],
-              path_params=[u'masterProjectId', u'zone'],
+              method_id=u'container.mainProjects.zones.tokens.create',
+              ordered_params=[u'mainProjectId', u'zone'],
+              path_params=[u'mainProjectId', u'zone'],
               query_params=[],
-              relative_path=u'v1/masterProjects/{masterProjectId}/zones/{zone}/tokens',
+              relative_path=u'v1/mainProjects/{mainProjectId}/zones/{zone}/tokens',
               request_field=u'createTokenRequest',
-              request_type_name=u'ContainerMasterProjectsZonesTokensCreateRequest',
+              request_type_name=u'ContainerMainProjectsZonesTokensCreateRequest',
               response_type_name=u'Token',
               supports_download=False,
           ),
@@ -110,11 +110,11 @@ https://cloud.google.com/storage/docs/access-control#Signed-URLs
 
     def Create(self, request, global_params=None):
       """Creates a compute-read-write (https://www.googleapis.com/auth/compute).
-scoped OAuth2 access token for <project_number>, to allow a hosted master
+scoped OAuth2 access token for <project_number>, to allow a hosted main
 to make modifications to its user's project.
 
       Args:
-        request: (ContainerMasterProjectsZonesTokensCreateRequest) input message
+        request: (ContainerMainProjectsZonesTokensCreateRequest) input message
         global_params: (StandardQueryParameters, default: None) global arguments
       Returns:
         (Token) The response message.
@@ -123,26 +123,26 @@ to make modifications to its user's project.
       return self._RunMethod(
           config, request, global_params=global_params)
 
-  class MasterProjectsZonesService(base_api.BaseApiService):
-    """Service class for the masterProjects_zones resource."""
+  class MainProjectsZonesService(base_api.BaseApiService):
+    """Service class for the mainProjects_zones resource."""
 
-    _NAME = u'masterProjects_zones'
+    _NAME = u'mainProjects_zones'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsZonesService, self).__init__(client)
+      super(ContainerV1.MainProjectsZonesService, self).__init__(client)
       self._method_configs = {
           }
 
       self._upload_configs = {
           }
 
-  class MasterProjectsService(base_api.BaseApiService):
-    """Service class for the masterProjects resource."""
+  class MainProjectsService(base_api.BaseApiService):
+    """Service class for the mainProjects resource."""
 
-    _NAME = u'masterProjects'
+    _NAME = u'mainProjects'
 
     def __init__(self, client):
-      super(ContainerV1.MasterProjectsService, self).__init__(client)
+      super(ContainerV1.MainProjectsService, self).__init__(client)
       self._method_configs = {
           }
 

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_messages.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/container/v1/container_v1_messages.py
@@ -45,8 +45,8 @@ class Cluster(_messages.Message):
       automatically chosen or specify a `/14` block in `10.0.0.0/8`.
     createTime: [Output only] The time the cluster was created, in
       [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.
-    currentMasterVersion: [Output only] The current software version of the
-      master endpoint.
+    currentMainVersion: [Output only] The current software version of the
+      main endpoint.
     currentNodeCount: [Output only] The number of nodes currently in the
       cluster.
     currentNodeVersion: [Output only] The current version of the node software
@@ -54,11 +54,11 @@ class Cluster(_messages.Message):
       in the process of being upgraded, this reflects the minimum version of
       all nodes.
     description: An optional description of this cluster.
-    endpoint: [Output only] The IP address of this cluster's master endpoint.
+    endpoint: [Output only] The IP address of this cluster's main endpoint.
       The endpoint can be accessed from the internet at
-      `https://username:password@endpoint/`.  See the `masterAuth` property of
+      `https://username:password@endpoint/`.  See the `mainAuth` property of
       this resource for username and password information.
-    initialClusterVersion: [Output only] The software version of the master
+    initialClusterVersion: [Output only] The software version of the main
       endpoint and kubelets used in the cluster when it was first created. The
       version can be upgraded over time.
     initialNodeCount: The number of nodes to create in this cluster. You must
@@ -76,7 +76,7 @@ class Cluster(_messages.Message):
       Cloud Logging service. * `none` - no logs will be exported from the
       cluster. * if left as an empty string,`logging.googleapis.com` will be
       used.
-    masterAuth: The authentication information for accessing the master
+    mainAuth: The authentication information for accessing the main
       endpoint.
     monitoringService: The monitoring service the cluster should use to write
       metrics. Currently available options:  * `monitoring.googleapis.com` -
@@ -131,7 +131,7 @@ class Cluster(_messages.Message):
       RUNNING: The RUNNING state indicates the cluster has been created and is
         fully usable.
       RECONCILING: The RECONCILING state indicates that some work is actively
-        being done on the cluster, such as upgrading the master or node
+        being done on the cluster, such as upgrading the main or node
         software. Details can be found in the `statusMessage` field.
       STOPPING: The STOPPING state indicates the cluster is being deleted.
       ERROR: The ERROR state indicates the cluster may be unusable. Details
@@ -147,7 +147,7 @@ class Cluster(_messages.Message):
   addonsConfig = _messages.MessageField('AddonsConfig', 1)
   clusterIpv4Cidr = _messages.StringField(2)
   createTime = _messages.StringField(3)
-  currentMasterVersion = _messages.StringField(4)
+  currentMainVersion = _messages.StringField(4)
   currentNodeCount = _messages.IntegerField(5, variant=_messages.Variant.INT32)
   currentNodeVersion = _messages.StringField(6)
   description = _messages.StringField(7)
@@ -156,7 +156,7 @@ class Cluster(_messages.Message):
   initialNodeCount = _messages.IntegerField(10, variant=_messages.Variant.INT32)
   instanceGroupUrls = _messages.StringField(11, repeated=True)
   loggingService = _messages.StringField(12)
-  masterAuth = _messages.MessageField('MasterAuth', 13)
+  mainAuth = _messages.MessageField('MainAuth', 13)
   monitoringService = _messages.StringField(14)
   name = _messages.StringField(15)
   network = _messages.StringField(16)
@@ -179,11 +179,11 @@ class ClusterUpdate(_messages.Message):
   Fields:
     desiredAddonsConfig: Configurations for the various addons available to
       run in the cluster.
-    desiredMasterMachineType: The name of a Google Compute Engine [machine
+    desiredMainMachineType: The name of a Google Compute Engine [machine
       type](/compute/docs/machine-types) (e.g. `n1-standard-8`) to change the
-      master to.
-    desiredMasterVersion:  Whitelisted and internal users can change the
-      master to any version.  The Kubernetes version to change the master to.
+      main to.
+    desiredMainVersion:  Whitelisted and internal users can change the
+      main to any version.  The Kubernetes version to change the main to.
       The only valid value is the latest supported version. Use "-" to have
       the server automatically select the latest version.
     desiredMonitoringService: The monitoring service the cluster should use to
@@ -199,44 +199,44 @@ class ClusterUpdate(_messages.Message):
   """
 
   desiredAddonsConfig = _messages.MessageField('AddonsConfig', 1)
-  desiredMasterMachineType = _messages.StringField(2)
-  desiredMasterVersion = _messages.StringField(3)
+  desiredMainMachineType = _messages.StringField(2)
+  desiredMainVersion = _messages.StringField(3)
   desiredMonitoringService = _messages.StringField(4)
   desiredNodePoolId = _messages.StringField(5)
   desiredNodeVersion = _messages.StringField(6)
 
 
-class ContainerMasterProjectsZonesSignedUrlsCreateRequest(_messages.Message):
-  """A ContainerMasterProjectsZonesSignedUrlsCreateRequest object.
+class ContainerMainProjectsZonesSignedUrlsCreateRequest(_messages.Message):
+  """A ContainerMainProjectsZonesSignedUrlsCreateRequest object.
 
   Fields:
     createSignedUrlsRequest: A CreateSignedUrlsRequest resource to be passed
       as the request body.
-    masterProjectId: The hosted master project in which this master resides.
+    mainProjectId: The hosted main project in which this main resides.
       This can be either a [project ID or project
       number](https://support.google.com/cloud/answer/6158840).
-    zone: The zone of this master's cluster.
+    zone: The zone of this main's cluster.
   """
 
   createSignedUrlsRequest = _messages.MessageField('CreateSignedUrlsRequest', 1)
-  masterProjectId = _messages.StringField(2, required=True)
+  mainProjectId = _messages.StringField(2, required=True)
   zone = _messages.StringField(3, required=True)
 
 
-class ContainerMasterProjectsZonesTokensCreateRequest(_messages.Message):
-  """A ContainerMasterProjectsZonesTokensCreateRequest object.
+class ContainerMainProjectsZonesTokensCreateRequest(_messages.Message):
+  """A ContainerMainProjectsZonesTokensCreateRequest object.
 
   Fields:
     createTokenRequest: A CreateTokenRequest resource to be passed as the
       request body.
-    masterProjectId: The hosted master project in which this master resides.
+    mainProjectId: The hosted main project in which this main resides.
       This can be either a [project ID or project
       number](https://support.google.com/cloud/answer/6158840).
-    zone: The zone of this master's cluster.
+    zone: The zone of this main's cluster.
   """
 
   createTokenRequest = _messages.MessageField('CreateTokenRequest', 1)
-  masterProjectId = _messages.StringField(2, required=True)
+  mainProjectId = _messages.StringField(2, required=True)
   zone = _messages.StringField(3, required=True)
 
 
@@ -467,14 +467,14 @@ class CreateNodePoolRequest(_messages.Message):
 
 class CreateSignedUrlsRequest(_messages.Message):
   """A request for signed URLs that allow for writing a file to a private GCS
-  bucket for storing backups of hosted master data.
+  bucket for storing backups of hosted main data.
 
   Fields:
-    clusterId: The name of this master's cluster.
+    clusterId: The name of this main's cluster.
     filenames: The names of the files for which a signed URLs are being
       requested.
     projectNumber: The project number for which the signed URLs are being
-      requested.  This is the project in which this master's cluster resides.
+      requested.  This is the project in which this main's cluster resides.
       Note that this must be a project number, not a project ID.
   """
 
@@ -486,13 +486,13 @@ class CreateSignedUrlsRequest(_messages.Message):
 class CreateTokenRequest(_messages.Message):
   """A request for a compute-read-write
   (https://www.googleapis.com/auth/compute) scoped OAuth2 access token for
-  <project_number>, to allow hosted masters to make modifications to a user's
+  <project_number>, to allow hosted mains to make modifications to a user's
   project.
 
   Fields:
-    clusterId: The name of this master's cluster.
+    clusterId: The name of this main's cluster.
     projectNumber: The project number for which the access is being requested.
-      This is the project in which this master's cluster resides.  Note that
+      This is the project in which this main's cluster resides.  Note that
       this must be a project number, not a project ID.
   """
 
@@ -564,8 +564,8 @@ class ListOperationsResponse(_messages.Message):
   operations = _messages.MessageField('Operation', 2, repeated=True)
 
 
-class MasterAuth(_messages.Message):
-  """The authentication information for accessing the master endpoint.
+class MainAuth(_messages.Message):
+  """The authentication information for accessing the main endpoint.
   Authentication can be done using HTTP basic auth or using client
   certificates.
 
@@ -576,10 +576,10 @@ class MasterAuth(_messages.Message):
       authenticate to the cluster endpoint.
     clusterCaCertificate: [Output only] Base64-encoded public certificate that
       is the root of trust for the cluster.
-    password: The password to use for HTTP basic authentication to the master
-      endpoint. Because the master endpoint is open to the Internet, you
+    password: The password to use for HTTP basic authentication to the main
+      endpoint. Because the main endpoint is open to the Internet, you
       should create a strong password.
-    username: The username to use for HTTP basic authentication to the master
+    username: The username to use for HTTP basic authentication to the main
       endpoint.
   """
 
@@ -728,7 +728,7 @@ class NodeConfig(_messages.Message):
 class NodePool(_messages.Message):
   """NodePool contains the name and configuration for a cluster's node pool.
   Node pools are a set of nodes (i.e. VM's), with a common configuration and
-  specification, under the control of the cluster master. They may have a set
+  specification, under the control of the cluster main. They may have a set
   of Kubernetes labels applied to them, which may be used to reference them
   during pod scheduling. They may also be resized up or down, to accommodate
   the workload.
@@ -780,7 +780,7 @@ class Operation(_messages.Message):
       TYPE_UNSPECIFIED: Not set.
       CREATE_CLUSTER: Cluster create.
       DELETE_CLUSTER: Cluster delete.
-      UPGRADE_MASTER: A master upgrade.
+      UPGRADE_MASTER: A main upgrade.
       UPGRADE_NODES: A node upgrade.
       REPAIR_CLUSTER: Cluster repair.
       UPDATE_CLUSTER: Cluster update.
@@ -838,7 +838,7 @@ class ServerConfig(_messages.Message):
 
 class SignedUrls(_messages.Message):
   """Signed URLs that allow for writing a file to a private GCS bucket for
-  storing backups of hosted master data.
+  storing backups of hosted main data.
 
   Fields:
     signedUrls: The signed URLs for writing the request files, in the same
@@ -917,7 +917,7 @@ class StandardQueryParameters(_messages.Message):
 
 class Token(_messages.Message):
   """A compute-read-write (https://www.googleapis.com/auth/compute) scoped
-  OAuth2 access token, to allow hosted masters to make modifications to a
+  OAuth2 access token, to allow hosted mains to make modifications to a
   user's project.
 
   Fields:

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/dataproc/v1/dataproc_v1_messages.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/dataproc/v1/dataproc_v1_messages.py
@@ -79,14 +79,14 @@ class ClusterConfig(_messages.Message):
     gceClusterConfig: [Required] The shared Google Compute Engine config
       settings for all instances in a cluster.
     initializationActions: [Optional] Commands to execute on each node after
-      config is completed. By default, executables are run on master and all
+      config is completed. By default, executables are run on main and all
       worker nodes. You can test a node's <code>role</code> metadata to run an
-      executable on a master or worker node, as shown below:
+      executable on a main or worker node, as shown below:
       ROLE=$(/usr/share/google/get_metadata_value attributes/role)     if [[
-      "${ROLE}" == 'Master' ]]; then       ... master specific actions ...
+      "${ROLE}" == 'Main' ]]; then       ... main specific actions ...
       else       ... worker specific actions ...     fi
-    masterConfig: [Optional] The Google Compute Engine config settings for the
-      master instance in a cluster.
+    mainConfig: [Optional] The Google Compute Engine config settings for the
+      main instance in a cluster.
     secondaryWorkerConfig: [Optional] The Google Compute Engine config
       settings for additional worker instances in a cluster.
     softwareConfig: [Optional] The config settings for software inside the
@@ -98,7 +98,7 @@ class ClusterConfig(_messages.Message):
   configBucket = _messages.StringField(1)
   gceClusterConfig = _messages.MessageField('GceClusterConfig', 2)
   initializationActions = _messages.MessageField('NodeInitializationAction', 3, repeated=True)
-  masterConfig = _messages.MessageField('InstanceGroupConfig', 4)
+  mainConfig = _messages.MessageField('InstanceGroupConfig', 4)
   secondaryWorkerConfig = _messages.MessageField('InstanceGroupConfig', 5)
   softwareConfig = _messages.MessageField('SoftwareConfig', 6)
   workerConfig = _messages.MessageField('InstanceGroupConfig', 7)
@@ -869,7 +869,7 @@ class HiveJob(_messages.Message):
 
 class InstanceGroupConfig(_messages.Message):
   """The config settings for Google Compute Engine resources in an instance
-  group, such as a master or worker group.
+  group, such as a main or worker group.
 
   Fields:
     diskConfig: Disk option config settings.
@@ -888,7 +888,7 @@ class InstanceGroupConfig(_messages.Message):
     managedGroupConfig: [Output-only] The config for Google Compute Engine
       Instance Group Manager that manages this group. This is only used for
       preemptible instance groups.
-    numInstances: The number of VM instances in the instance group. For master
+    numInstances: The number of VM instances in the instance group. For main
       instance groups, must be set to 1.
   """
 

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/genomics/v1/genomics_v1_messages.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/genomics/v1/genomics_v1_messages.py
@@ -806,8 +806,8 @@ class ImportVariantsRequest(_messages.Message):
       FORMAT_UNSPECIFIED: <no description>
       FORMAT_VCF: VCF (Variant Call Format). The VCF files should be
         uncompressed. gVCF is also supported.
-      FORMAT_COMPLETE_GENOMICS: Complete Genomics masterVarBeta format. The
-        masterVarBeta files should be bzip2 compressed.
+      FORMAT_COMPLETE_GENOMICS: Complete Genomics mainVarBeta format. The
+        mainVarBeta files should be bzip2 compressed.
     """
     FORMAT_UNSPECIFIED = 0
     FORMAT_VCF = 1

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
@@ -150,7 +150,7 @@ class DatabaseInstance(_messages.Message):
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     project: The project ID of the project containing the Cloud SQL instance.
@@ -179,7 +179,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 6, repeated=True)
   ipv6Address = _messages.StringField(7)
   kind = _messages.StringField(8, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(9)
+  mainInstanceName = _messages.StringField(9)
   maxDiskSize = _messages.IntegerField(10)
   project = _messages.StringField(11)
   region = _messages.StringField(12)

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/sqladmin/v1beta4/sqladmin_v1beta4_messages.py
@@ -201,14 +201,14 @@ class DatabaseInstance(_messages.Message):
       property is applicable only to Second Generation instances.
     instanceType: The instance type. This can be one of the following.
       CLOUD_SQL_INSTANCE: A Cloud SQL instance that is not replicating from a
-      master. ON_PREMISES_INSTANCE: An instance running on the customer's
+      main. ON_PREMISES_INSTANCE: An instance running on the customer's
       premises. READ_REPLICA_INSTANCE: A Cloud SQL instance configured as a
       read-replica.
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance. This property is
       applicable only to First Generation instances.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     name: Name of the Cloud SQL instance. This does not include the project
@@ -222,7 +222,7 @@ class DatabaseInstance(_messages.Message):
       type (First Generation or Second Generation). The region can not be
       changed after instance creation.
     replicaConfiguration: Configuration specific to read-replicas replicating
-      from on-premises masters.
+      from on-premises mains.
     replicaNames: The replicas of the instance.
     selfLink: The URI of this resource.
     serverCaCert: SSL configuration.
@@ -247,7 +247,7 @@ class DatabaseInstance(_messages.Message):
 
     Fields:
       available: The availability status of the failover replica. A false
-        status indicates that the failover replica is out of sync. The master
+        status indicates that the failover replica is out of sync. The main
         can only failover to the falover replica when the status is true.
       name: The name of the failover replica.
     """
@@ -264,7 +264,7 @@ class DatabaseInstance(_messages.Message):
   ipAddresses = _messages.MessageField('IpMapping', 7, repeated=True)
   ipv6Address = _messages.StringField(8)
   kind = _messages.StringField(9, default=u'sql#instance')
-  masterInstanceName = _messages.StringField(10)
+  mainInstanceName = _messages.StringField(10)
   maxDiskSize = _messages.IntegerField(11)
   name = _messages.StringField(12)
   onPremisesConfiguration = _messages.MessageField('OnPremisesConfiguration', 13)
@@ -580,24 +580,24 @@ class MySqlReplicaConfiguration(_messages.Message):
 
   Fields:
     caCertificate: PEM representation of the trusted CA's x509 certificate.
-    clientCertificate: PEM representation of the slave's x509 certificate.
-    clientKey: PEM representation of the slave's private key. The
+    clientCertificate: PEM representation of the subordinate's x509 certificate.
+    clientKey: PEM representation of the subordinate's private key. The
       corresponsing public key is encoded in the client's certificate.
     connectRetryInterval: Seconds to wait between connect retries. MySQL's
       default is 60 seconds.
     dumpFilePath: Path to a SQL dump file in Google Cloud Storage from which
-      the slave instance is to be created. The URI is in the form
+      the subordinate instance is to be created. The URI is in the form
       gs://bucketName/fileName. Compressed gzip files (.gz) are also
       supported. Dumps should have the binlog co-ordinates from which
-      replication should begin. This can be accomplished by setting --master-
+      replication should begin. This can be accomplished by setting --main-
       data to 1 when using mysqldump.
     kind: This is always sql#mysqlReplicaConfiguration.
-    masterHeartbeatPeriod: Interval in milliseconds between replication
+    mainHeartbeatPeriod: Interval in milliseconds between replication
       heartbeats.
     password: The password for the replication connection.
     sslCipher: A list of permissible ciphers to use for SSL encryption.
     username: The username for the replication connection.
-    verifyServerCertificate: Whether or not to check the master's Common Name
+    verifyServerCertificate: Whether or not to check the main's Common Name
       value in the certificate that it sends during the SSL handshake.
   """
 
@@ -607,7 +607,7 @@ class MySqlReplicaConfiguration(_messages.Message):
   connectRetryInterval = _messages.IntegerField(4, variant=_messages.Variant.INT32)
   dumpFilePath = _messages.StringField(5)
   kind = _messages.StringField(6, default=u'sql#mysqlReplicaConfiguration')
-  masterHeartbeatPeriod = _messages.IntegerField(7)
+  mainHeartbeatPeriod = _messages.IntegerField(7)
   password = _messages.StringField(8)
   sslCipher = _messages.StringField(9)
   username = _messages.StringField(10)
@@ -721,22 +721,22 @@ class OperationsListResponse(_messages.Message):
 
 
 class ReplicaConfiguration(_messages.Message):
-  """Read-replica configuration for connecting to the master.
+  """Read-replica configuration for connecting to the main.
 
   Fields:
     failoverTarget: Specifies if the replica is the failover target. If the
       field is set to true the replica will be designated as a failover
-      replica. In case the master instance fails, the replica instance will be
-      promoted as the new master instance. Only one replica can be specified
+      replica. In case the main instance fails, the replica instance will be
+      promoted as the new main instance. Only one replica can be specified
       as failover target, and the replica has to be in different zone with the
-      master instance.
+      main instance.
     kind: This is always sql#replicaConfiguration.
     mysqlReplicaConfiguration: MySQL specific configuration when replicating
-      from a MySQL on-premises master. Replication configuration information
+      from a MySQL on-premises main. Replication configuration information
       such as the username, password, certificates, and keys are not stored in
       the instance metadata. The configuration information is used only to set
       up the replication connection and is stored by MySQL in a file named
-      master.info in the data directory.
+      main.info in the data directory.
   """
 
   failoverTarget = _messages.BooleanField(1)

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/apitools/base/py/batch.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/apitools/base/py/batch.py
@@ -174,7 +174,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/google-cloud-sdk/lib/googlecloudsdk/third_party/appengine/proto/protocoltype_pb.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/third_party/appengine/proto/protocoltype_pb.py
@@ -1053,8 +1053,8 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
   proto_name_ = ""
   has_proto2_file_descriptor_ = 0
   proto2_file_descriptor_ = ""
-  has_proto2_file_master_ = 0
-  proto2_file_master_ = ""
+  has_proto2_file_main_ = 0
+  proto2_file_main_ = ""
   has_proto2_name_ = 0
   proto2_name_ = ""
   has_proto2_extension_info_ = 0
@@ -1151,18 +1151,18 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
 
   def has_proto2_file_descriptor(self): return self.has_proto2_file_descriptor_
 
-  def proto2_file_master(self): return self.proto2_file_master_
+  def proto2_file_main(self): return self.proto2_file_main_
 
-  def set_proto2_file_master(self, x):
-    self.has_proto2_file_master_ = 1
-    self.proto2_file_master_ = x
+  def set_proto2_file_main(self, x):
+    self.has_proto2_file_main_ = 1
+    self.proto2_file_main_ = x
 
-  def clear_proto2_file_master(self):
-    if self.has_proto2_file_master_:
-      self.has_proto2_file_master_ = 0
-      self.proto2_file_master_ = ""
+  def clear_proto2_file_main(self):
+    if self.has_proto2_file_main_:
+      self.has_proto2_file_main_ = 0
+      self.proto2_file_main_ = ""
 
-  def has_proto2_file_master(self): return self.has_proto2_file_master_
+  def has_proto2_file_main(self): return self.has_proto2_file_main_
 
   def proto2_name(self): return self.proto2_name_
 
@@ -1212,7 +1212,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     for i in xrange(x.tag_size()): self.add_tag().CopyFrom(x.tag(i))
     for i in xrange(x.enumtype_size()): self.add_enumtype().CopyFrom(x.enumtype(i))
     if (x.has_proto2_file_descriptor()): self.set_proto2_file_descriptor(x.proto2_file_descriptor())
-    if (x.has_proto2_file_master()): self.set_proto2_file_master(x.proto2_file_master())
+    if (x.has_proto2_file_main()): self.set_proto2_file_main(x.proto2_file_main())
     if (x.has_proto2_name()): self.set_proto2_name(x.proto2_name())
     if (x.has_proto2_extension_info()): self.set_proto2_extension_info(x.proto2_extension_info())
     if (x.has_proto2_file_scope_info()): self.set_proto2_file_scope_info(x.proto2_file_scope_info())
@@ -1260,8 +1260,8 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
       if e1 != e2: return 0
     if self.has_proto2_file_descriptor_ != x.has_proto2_file_descriptor_: return 0
     if self.has_proto2_file_descriptor_ and self.proto2_file_descriptor_ != x.proto2_file_descriptor_: return 0
-    if self.has_proto2_file_master_ != x.has_proto2_file_master_: return 0
-    if self.has_proto2_file_master_ and self.proto2_file_master_ != x.proto2_file_master_: return 0
+    if self.has_proto2_file_main_ != x.has_proto2_file_main_: return 0
+    if self.has_proto2_file_main_ and self.proto2_file_main_ != x.proto2_file_main_: return 0
     if self.has_proto2_name_ != x.has_proto2_name_: return 0
     if self.has_proto2_name_ and self.proto2_name_ != x.proto2_name_: return 0
     if self.has_proto2_extension_info_ != x.has_proto2_extension_info_: return 0
@@ -1296,7 +1296,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     n += 2 * len(self.enumtype_)
     for i in xrange(len(self.enumtype_)): n += self.enumtype_[i].ByteSize()
     if (self.has_proto2_file_descriptor_): n += 2 + self.lengthString(len(self.proto2_file_descriptor_))
-    if (self.has_proto2_file_master_): n += 2 + self.lengthString(len(self.proto2_file_master_))
+    if (self.has_proto2_file_main_): n += 2 + self.lengthString(len(self.proto2_file_main_))
     if (self.has_proto2_name_): n += 2 + self.lengthString(len(self.proto2_name_))
     if (self.has_proto2_extension_info_): n += 2 + self.lengthString(len(self.proto2_extension_info_))
     if (self.has_proto2_file_scope_info_): n += 2 + self.lengthString(len(self.proto2_file_scope_info_))
@@ -1316,7 +1316,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     n += 2 * len(self.enumtype_)
     for i in xrange(len(self.enumtype_)): n += self.enumtype_[i].ByteSizePartial()
     if (self.has_proto2_file_descriptor_): n += 2 + self.lengthString(len(self.proto2_file_descriptor_))
-    if (self.has_proto2_file_master_): n += 2 + self.lengthString(len(self.proto2_file_master_))
+    if (self.has_proto2_file_main_): n += 2 + self.lengthString(len(self.proto2_file_main_))
     if (self.has_proto2_name_): n += 2 + self.lengthString(len(self.proto2_name_))
     if (self.has_proto2_extension_info_): n += 2 + self.lengthString(len(self.proto2_extension_info_))
     if (self.has_proto2_file_scope_info_): n += 2 + self.lengthString(len(self.proto2_file_scope_info_))
@@ -1329,7 +1329,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     self.clear_tag()
     self.clear_enumtype()
     self.clear_proto2_file_descriptor()
-    self.clear_proto2_file_master()
+    self.clear_proto2_file_main()
     self.clear_proto2_name()
     self.clear_proto2_extension_info()
     self.clear_proto2_file_scope_info()
@@ -1350,9 +1350,9 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     if (self.has_proto2_file_descriptor_):
       out.putVarInt32(186)
       out.putPrefixedString(self.proto2_file_descriptor_)
-    if (self.has_proto2_file_master_):
+    if (self.has_proto2_file_main_):
       out.putVarInt32(194)
-      out.putPrefixedString(self.proto2_file_master_)
+      out.putPrefixedString(self.proto2_file_main_)
     if (self.has_proto2_name_):
       out.putVarInt32(202)
       out.putPrefixedString(self.proto2_name_)
@@ -1384,9 +1384,9 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     if (self.has_proto2_file_descriptor_):
       out.putVarInt32(186)
       out.putPrefixedString(self.proto2_file_descriptor_)
-    if (self.has_proto2_file_master_):
+    if (self.has_proto2_file_main_):
       out.putVarInt32(194)
-      out.putPrefixedString(self.proto2_file_master_)
+      out.putPrefixedString(self.proto2_file_main_)
     if (self.has_proto2_name_):
       out.putVarInt32(202)
       out.putPrefixedString(self.proto2_name_)
@@ -1419,7 +1419,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
         self.set_proto2_file_descriptor(d.getPrefixedString())
         continue
       if tt == 194:
-        self.set_proto2_file_master(d.getPrefixedString())
+        self.set_proto2_file_main(d.getPrefixedString())
         continue
       if tt == 202:
         self.set_proto2_name(d.getPrefixedString())
@@ -1461,7 +1461,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
       res+=prefix+"}\n"
       cnt+=1
     if self.has_proto2_file_descriptor_: res+=prefix+("proto2_file_descriptor: %s\n" % self.DebugFormatString(self.proto2_file_descriptor_))
-    if self.has_proto2_file_master_: res+=prefix+("proto2_file_master: %s\n" % self.DebugFormatString(self.proto2_file_master_))
+    if self.has_proto2_file_main_: res+=prefix+("proto2_file_main: %s\n" % self.DebugFormatString(self.proto2_file_main_))
     if self.has_proto2_name_: res+=prefix+("proto2_name: %s\n" % self.DebugFormatString(self.proto2_name_))
     if self.has_proto2_extension_info_: res+=prefix+("proto2_extension_info: %s\n" % self.DebugFormatString(self.proto2_extension_info_))
     if self.has_proto2_file_scope_info_: res+=prefix+("proto2_file_scope_info: %s\n" % self.DebugFormatString(self.proto2_file_scope_info_))
@@ -1499,7 +1499,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
   kEnumTypeproto2_name = 31
   kEnumTypeallow_alias = 33
   kproto2_file_descriptor = 23
-  kproto2_file_master = 24
+  kproto2_file_main = 24
   kproto2_name = 25
   kproto2_extension_info = 29
   kproto2_file_scope_info = 30
@@ -1529,7 +1529,7 @@ class ProtocolDescriptor(ProtocolBuffer.ProtocolMessage):
     21: "name",
     22: "value",
     23: "proto2_file_descriptor",
-    24: "proto2_file_master",
+    24: "proto2_file_main",
     25: "proto2_name",
     26: "deprecated",
     27: "proto_name",

--- a/google-cloud-sdk/lib/surface/container/clusters/get_credentials.py
+++ b/google-cloud-sdk/lib/surface/container/clusters/get_credentials.py
@@ -58,7 +58,7 @@ class GetCredentials(base.Command):
     log.status.Print('Fetching cluster endpoint and auth data.')
     # Call DescribeCluster to get auth info and cache for next time
     cluster = adapter.GetCluster(cluster_ref)
-    if not cluster.masterAuth:
+    if not cluster.mainAuth:
       raise util.Error(
           'get-credentials requires edit permission on {0}'.format(
               cluster_ref.projectId))

--- a/google-cloud-sdk/lib/surface/container/clusters/upgrade.py
+++ b/google-cloud-sdk/lib/surface/container/clusters/upgrade.py
@@ -43,20 +43,20 @@ To upgrade nodes to the latest available version, run
 
 
 class VersionVerifier(object):
-  """Compares the cluster and master versions for upgrade availablity."""
+  """Compares the cluster and main versions for upgrade availablity."""
   UP_TO_DATE = 0
   UPGRADE_AVAILABLE = 1
   SUPPORT_ENDING = 2
   UNSUPPORTED = 3
 
-  def Compare(self, current_master_version, current_cluster_version):
-    """Compares the cluster and master versions and returns an enum."""
-    # TODO(user):update the if condition when we roll the master version
-    if current_master_version == current_cluster_version:
+  def Compare(self, current_main_version, current_cluster_version):
+    """Compares the cluster and main versions and returns an enum."""
+    # TODO(user):update the if condition when we roll the main version
+    if current_main_version == current_cluster_version:
       return self.UP_TO_DATE
-    master_version = SemVer(current_master_version)
+    main_version = SemVer(current_main_version)
     cluster_version = SemVer(current_cluster_version)
-    major, minor, _ = master_version.Distance(cluster_version)
+    major, minor, _ = main_version.Distance(cluster_version)
     if major != 0 or minor > 2:
       return self.UNSUPPORTED
     elif minor > 1:
@@ -85,19 +85,19 @@ class Upgrade(base.Command):
         '--cluster-version',
         help='The Kubernetes release version to which to upgrade the'
         ' cluster\'s nodes. Omit to upgrade the nodes to the version the'
-        ' cluster\'s Kubernetes master is running.')
+        ' cluster\'s Kubernetes main is running.')
     cv.detailed_help = """\
       The Kubernetes release version to which to upgrade the cluster's nodes.
-      Omit to upgrade the nodes to the version the cluster's Kubernetes master
+      Omit to upgrade the nodes to the version the cluster's Kubernetes main
       is running.
 
       If provided, the --cluster-version must be no greater than the cluster
-      master's minor version (x.*X*.x), and must be a latest patch version
+      main's minor version (x.*X*.x), and must be a latest patch version
       (x.x.*X*).
 
-      You can find the current master version by running
+      You can find the current main version by running
 
-        $ gcloud container clusters describe <cluster> | grep MasterVersion
+        $ gcloud container clusters describe <cluster> | grep MainVersion
 
       You can find the list of allowed node versions for upgrades by running
 
@@ -109,10 +109,10 @@ class Upgrade(base.Command):
         '--node-pool',
         help='The node pool to upgrade.')
     parser.add_argument(
-        '--master',
-        help='Upgrade the cluster\'s master to the latest version of Kubernetes'
+        '--main',
+        help='Upgrade the cluster\'s main to the latest version of Kubernetes'
         ' supported on Container Engine. Nodes cannot be upgraded at the same'
-        ' time as the master.',
+        ' time as the main.',
         action='store_true')
     parser.add_argument(
         '--wait',
@@ -140,8 +140,8 @@ class Upgrade(base.Command):
 
     options = api_adapter.UpdateClusterOptions(
         version=args.cluster_version,
-        update_master=args.master,
-        update_nodes=(not args.master),
+        update_main=args.main,
+        update_nodes=(not args.main),
         node_pool=args.node_pool)
 
     if options.version:
@@ -149,9 +149,9 @@ class Upgrade(base.Command):
     else:
       new_version = 'latest'
 
-    if args.master:
-      node_message = 'Master'
-      current_version = cluster.currentMasterVersion
+    if args.main:
+      node_message = 'Main'
+      current_version = cluster.currentMainVersion
     else:
       node_message = 'All {node_count} nodes'.format(
           node_count=cluster.currentNodeCount)
@@ -186,7 +186,7 @@ Upgrade.detailed_help = {
       Upgrades the Kubernetes version of an existing container cluster.
 
       This command upgrades the Kubernetes version of the *nodes* of a cluster.
-      The Kubernetes version of the cluster's *master* is periodically upgraded
+      The Kubernetes version of the cluster's *main* is periodically upgraded
       automatically as new releases are available.
 
       *By running this command, all of the cluster's nodes will be deleted and*
@@ -202,7 +202,7 @@ Upgrade.detailed_help = {
     """,
     'EXAMPLES': """\
       Upgrade the nodes of <cluster> to the Kubernetes version of the cluster's
-      master.
+      main.
 
         $ {command} <cluster>
 

--- a/google-cloud-sdk/lib/surface/dataproc/clusters/create.py
+++ b/google-cloud-sdk/lib/surface/dataproc/clusters/create.py
@@ -63,8 +63,8 @@ class Create(base.Command):
         type=int,
         help='The number of preemptible worker nodes in the cluster.')
     parser.add_argument(
-        '--master-machine-type',
-        help='The type of machine to use for the master. Defaults to '
+        '--main-machine-type',
+        help='The type of machine to use for the main. Defaults to '
         'server-specified.')
     parser.add_argument(
         '--worker-machine-type',
@@ -107,17 +107,17 @@ class Create(base.Command):
         type=int,
         help='The number of local SSDs to attach to each worker in a cluster.')
     parser.add_argument(
-        '--num-master-local-ssds',
+        '--num-main-local-ssds',
         type=int,
-        help='The number of local SSDs to attach to the master in a cluster.')
+        help='The number of local SSDs to attach to the main in a cluster.')
     parser.add_argument(
         '--worker-boot-disk-size-gb',
         type=int,
         help='The size in GB of the boot disk of each worker in a cluster.')
     parser.add_argument(
-        '--master-boot-disk-size-gb',
+        '--main-boot-disk-size-gb',
         type=int,
-        help='The size in GB of the boot disk of the master in a cluster.')
+        help='The size in GB of the boot disk of the main in a cluster.')
     parser.add_argument(
         '--initialization-actions',
         type=arg_parsers.ArgList(min_length=1),
@@ -215,7 +215,7 @@ Alias,URI
     compute_uris = config_helper.ResolveGceUris(
         args.name,
         args.image,
-        args.master_machine_type,
+        args.main_machine_type,
         args.worker_machine_type,
         args.network,
         args.subnet)
@@ -251,12 +251,12 @@ Alias,URI
     cluster_config = messages.ClusterConfig(
         configBucket=args.bucket,
         gceClusterConfig=gce_cluster_config,
-        masterConfig=messages.InstanceGroupConfig(
+        mainConfig=messages.InstanceGroupConfig(
             imageUri=compute_uris['image'],
-            machineTypeUri=compute_uris['master_machine_type'],
+            machineTypeUri=compute_uris['main_machine_type'],
             diskConfig=messages.DiskConfig(
-                bootDiskSizeGb=args.master_boot_disk_size_gb,
-                numLocalSsds=args.num_master_local_ssds,
+                bootDiskSizeGb=args.main_boot_disk_size_gb,
+                numLocalSsds=args.num_main_local_ssds,
             ),
         ),
         workerConfig=messages.InstanceGroupConfig(

--- a/google-cloud-sdk/lib/surface/functions/deploy.py
+++ b/google-cloud-sdk/lib/surface/functions/deploy.py
@@ -65,7 +65,7 @@ class Deploy(base.Command):
               'One of the parameters --source-revision, --source-branch, '
               'or --source-tag can be given to specify the version in the '
               'repository. If none of them are provided, the last revision '
-              'from the master branch is used. If this parameter is given, '
+              'from the main branch is used. If this parameter is given, '
               'the parameter --source is required and describes the path '
               'inside the repository.'))
     source_version_group = parser.add_mutually_exclusive_group()

--- a/google-cloud-sdk/lib/surface/source/repos/clone.py
+++ b/google-cloud-sdk/lib/surface/source/repos/clone.py
@@ -45,7 +45,7 @@ class Clone(base.Command):
             $ gcloud source repos clone default TARGET_DIR
             $ cd TARGET_DIR
             ... create/edit files and create one or more commits ...
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/google-cloud-sdk/lib/surface/sql/instances/create.py
+++ b/google-cloud-sdk/lib/surface/sql/instances/create.py
@@ -112,11 +112,11 @@ class _BaseCreate(object):
         'instance',
         help='Cloud SQL instance ID.')
     parser.add_argument(
-        '--master-instance-name',
+        '--main-instance-name',
         required=False,
-        help='Name of the instance which will act as master in the replication '
+        help='Name of the instance which will act as main in the replication '
         'setup. The newly created instance will be a read replica of the '
-        'specified master instance.')
+        'specified main instance.')
     parser.add_argument(
         '--on-premises-host-port',
         required=False,

--- a/google-cloud-sdk/lib/third_party/dns/rdataset.py
+++ b/google-cloud-sdk/lib/third_party/dns/rdataset.py
@@ -169,7 +169,7 @@ class Rdataset(dns.set.Set):
 
     def to_text(self, name=None, origin=None, relativize=True,
                 override_rdclass=None, **kw):
-        """Convert the rdataset into DNS master file format.
+        """Convert the rdataset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/google-cloud-sdk/lib/third_party/dns/rdtypes/ANY/SOA.py
+++ b/google-cloud-sdk/lib/third_party/dns/rdtypes/ANY/SOA.py
@@ -22,7 +22,7 @@ import dns.name
 class SOA(dns.rdata.Rdata):
     """SOA record
 
-    @ivar mname: the SOA MNAME (master name) field
+    @ivar mname: the SOA MNAME (main name) field
     @type mname: dns.name.Name object
     @ivar rname: the SOA RNAME (responsible name) field
     @type rname: dns.name.Name object

--- a/google-cloud-sdk/lib/third_party/dns/rrset.py
+++ b/google-cloud-sdk/lib/third_party/dns/rrset.py
@@ -84,7 +84,7 @@ class RRset(dns.rdataset.Rdataset):
         return True
 
     def to_text(self, origin=None, relativize=True, **kw):
-        """Convert the RRset into DNS master file format.
+        """Convert the RRset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/google-cloud-sdk/lib/third_party/dns/tokenizer.py
+++ b/google-cloud-sdk/lib/third_party/dns/tokenizer.py
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Tokenize DNS master file format"""
+"""Tokenize DNS main file format"""
 
 import cStringIO
 import sys
@@ -47,7 +47,7 @@ class UngetBufferFull(dns.exception.DNSException):
     pass
 
 class Token(object):
-    """A DNS master file format token.
+    """A DNS main file format token.
 
     @ivar ttype: The token type
     @type ttype: int
@@ -156,7 +156,7 @@ class Token(object):
             raise IndexError
 
 class Tokenizer(object):
-    """A DNS master file format tokenizer.
+    """A DNS main file format tokenizer.
 
     A token is a (type, value) tuple, where I{type} is an int, and
     I{value} is a string.  The valid types are EOF, EOL, WHITESPACE,

--- a/google-cloud-sdk/lib/third_party/dns/zone.py
+++ b/google-cloud-sdk/lib/third_party/dns/zone.py
@@ -520,8 +520,8 @@ class Zone(object):
             raise NoNS
 
 
-class _MasterReader(object):
-    """Read a DNS master file
+class _MainReader(object):
+    """Read a DNS main file
 
     @ivar tok: The tokenizer
     @type tok: dns.tokenizer.Tokenizer object
@@ -569,7 +569,7 @@ class _MasterReader(object):
                 break
 
     def _rr_line(self):
-        """Process one line from a DNS master file."""
+        """Process one line from a DNS main file."""
         # Name
         if self.current_origin is None:
             raise UnknownOrigin
@@ -642,7 +642,7 @@ class _MasterReader(object):
         rds.add(rd, ttl)
 
     def read(self):
-        """Read a DNS master file and build a zone object.
+        """Read a DNS main file and build a zone object.
 
         @raises dns.zone.NoSOA: No SOA RR was found at the zone origin
         @raises dns.zone.NoNS: No NS RRset was found at the zone origin
@@ -704,7 +704,7 @@ class _MasterReader(object):
                                                            filename)
                         self.current_origin = new_origin
                     else:
-                        raise dns.exception.SyntaxError("Unknown master file directive '" + u + "'")
+                        raise dns.exception.SyntaxError("Unknown main file directive '" + u + "'")
                     continue
                 self.tok.unget(token)
                 self._rr_line()
@@ -721,12 +721,12 @@ class _MasterReader(object):
 def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=False, check_origin=True):
-    """Build a zone object from a master file format string.
+    """Build a zone object from a main file format string.
 
-    @param text: the master file format input
+    @param text: the main file format input
     @type text: string.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.
@@ -755,7 +755,7 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
     if filename is None:
         filename = '<string>'
     tok = dns.tokenizer.Tokenizer(text, filename)
-    reader = _MasterReader(tok, origin, rdclass, relativize, zone_factory,
+    reader = _MainReader(tok, origin, rdclass, relativize, zone_factory,
                            allow_include=allow_include,
                            check_origin=check_origin)
     reader.read()
@@ -764,12 +764,12 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
 def from_file(f, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=True, check_origin=True):
-    """Read a master file and build a zone object.
+    """Read a main file and build a zone object.
 
     @param f: file or string.  If I{f} is a string, it is treated
     as the name of a file to open.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.

--- a/google-cloud-sdk/lib/third_party/dulwich/repo.py
+++ b/google-cloud-sdk/lib/third_party/dulwich/repo.py
@@ -790,8 +790,8 @@ class Repo(BaseRepo):
             b'refs/tags', self.refs.as_dict(b'refs/tags'))
         try:
             target.refs.add_if_new(
-                b'refs/heads/master',
-                self.refs[b'refs/heads/master'])
+                b'refs/heads/main',
+                self.refs[b'refs/heads/main'])
         except KeyError:
             pass
 
@@ -876,7 +876,7 @@ class Repo(BaseRepo):
             os.mkdir(os.path.join(path, *d))
         DiskObjectStore.init(os.path.join(path, OBJECTDIR))
         ret = cls(path)
-        ret.refs.set_symbolic_ref(b'HEAD', b"refs/heads/master")
+        ret.refs.set_symbolic_ref(b'HEAD', b"refs/heads/main")
         ret._init_files(bare)
         return ret
 

--- a/google-cloud-sdk/lib/third_party/jinja2/pkg_resources.py
+++ b/google-cloud-sdk/lib/third_party/jinja2/pkg_resources.py
@@ -2693,7 +2693,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 
 try:

--- a/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
+++ b/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
+++ b/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
@@ -126,7 +126,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://cloud.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/google-cloud-sdk/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
@@ -174,7 +174,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/google-cloud-sdk/platform/gsutil/third_party/apitools/run_pylint.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/apitools/run_pylint.py
@@ -118,9 +118,9 @@ def get_files_for_linting(allow_limited=True, diff_base=None):
     uses a specific commit or branch (a so-called diff base) to compare
     against for changed files. (This requires ``allow_limited=True``.)
 
-    To speed up linting on Travis pull requests against master, we manually
-    set the diff base to origin/master. We don't do this on non-pull requests
-    since origin/master will be equivalent to the currently checked out code.
+    To speed up linting on Travis pull requests against main, we manually
+    set the diff base to origin/main. We don't do this on non-pull requests
+    since origin/main will be equivalent to the currently checked out code.
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
@@ -137,14 +137,14 @@ def get_files_for_linting(allow_limited=True, diff_base=None):
               linted.
     """
     if os.getenv('TRAVIS') == 'true':
-        # In travis, don't default to master.
+        # In travis, don't default to main.
         diff_base = None
 
-    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+    if (os.getenv('TRAVIS_BRANCH') == 'main' and
             os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
-        # In the case of a pull request into master, we want to
-        # diff against HEAD in master.
-        diff_base = 'origin/master'
+        # In the case of a pull request into main, we want to
+        # diff against HEAD in main.
+        diff_base = 'origin/main'
 
     if diff_base is not None and allow_limited:
         result = subprocess.check_output(['git', 'diff', '--name-only',

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
@@ -398,8 +398,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -426,11 +426,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -461,7 +461,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -515,15 +515,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -710,15 +710,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/kms/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
@@ -139,8 +139,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -169,8 +169,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -399,8 +399,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -424,8 +424,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -563,7 +563,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -594,8 +594,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -681,8 +681,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
@@ -319,8 +319,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -415,9 +415,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -450,8 +450,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -534,7 +534,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -653,8 +653,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2478,7 +2478,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2606,14 +2606,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2624,7 +2624,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2658,7 +2658,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2810,8 +2810,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
@@ -182,7 +182,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -238,7 +238,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(response.instancegroups[0].name, "Main instance group")
         self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
         self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
@@ -566,7 +566,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -598,7 +598,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.status.state, 'TERMINATED')
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
-        self.assertEqual(response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -836,7 +836,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -853,7 +853,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -871,11 +871,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -903,14 +903,14 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -932,7 +932,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1000,5 +1000,5 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster' },
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/google-cloud-sdk/platform/gsutil/third_party/oauth2client/docs/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/oauth2client/docs/conf.py
@@ -23,7 +23,7 @@ extensions = [
 ]
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 # General information about the project.
 project = u'oauth2client'

--- a/google-cloud-sdk/platform/gsutil/third_party/rsa/doc/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/rsa/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Python-RSA'

--- a/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.